### PR TITLE
State Machine Diagram for Typestates

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -25,7 +25,7 @@ let currentStateMachine: StateMachine | undefined;
 
 /**
  * Activates the LiquidJava extension
- * @param context
+ * @param context The extension context
  */
 export async function activate(context: vscode.ExtensionContext) {
     initLogging(context);
@@ -68,7 +68,7 @@ export async function deactivate() {
 
 /**
  * Initializes logging for the extension with an output channel
- * @param context
+ * @param context The extension context
  */
 function initLogging(context: vscode.ExtensionContext) {
     outputChannel = vscode.window.createOutputChannel("LiquidJava");
@@ -80,7 +80,7 @@ function initLogging(context: vscode.ExtensionContext) {
 
 /**
  * Initializes the status bar for the extension
- * @param context
+ * @param context The extension context
  */
 function initStatusBar(context: vscode.ExtensionContext) {
     statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);
@@ -93,7 +93,7 @@ function initStatusBar(context: vscode.ExtensionContext) {
 
 /**
  * Initializes the command palette for the extension
- * @param context
+ * @param context The extension context
  */
 function initCommandPalette(context: vscode.ExtensionContext) {
     context.subscriptions.push(
@@ -112,7 +112,7 @@ function initCommandPalette(context: vscode.ExtensionContext) {
 
 /**
  * Initializes the webview panel for the extension
- * @param context
+ * @param context The extension context
  */
 function initWebview(context: vscode.ExtensionContext) {
     webviewProvider = new LiquidJavaWebviewProvider(context.extensionUri);
@@ -166,7 +166,7 @@ function initHover() {
 
 /**
  * Initializes file system event listeners
- * @param context
+ * @param context The extension context
  */
 function initFileEvents(context: vscode.ExtensionContext) {
     // listen for active text editor changes
@@ -183,6 +183,10 @@ function initFileEvents(context: vscode.ExtensionContext) {
     );
 }
 
+/**
+ * Requests the state machine for the given document from the language server
+ * @param document The text document
+ */
 async function requestStateMachine(document: vscode.TextDocument) {
     const sm: StateMachine = await client?.sendRequest("liquidjava/fsm", { uri: document.uri.toString() });
     webviewProvider?.sendMessage({ type: "fsm", sm });
@@ -191,7 +195,7 @@ async function requestStateMachine(document: vscode.TextDocument) {
 
 /**
  * Updates the status bar with the current state
- * @param state
+ * @param state The current state ("loading", "stopped", "passed", "failed")
  */
 function updateStatusBar(state: "loading" | "stopped" | "passed" | "failed") {
     const icons = {
@@ -207,8 +211,8 @@ function updateStatusBar(state: "loading" | "stopped" | "passed" | "failed") {
 
 /**
  * Runs the LiquidJava language server
- * @param context
- * @param javaExecutablePath
+ * @param context The extension context
+ * @param javaExecutablePath The path to the Java executable
  * @returns A promise to the port number the server is running on
  */
 async function runLanguageServer(context: vscode.ExtensionContext, javaExecutablePath: string): Promise<number> {
@@ -247,8 +251,8 @@ async function runLanguageServer(context: vscode.ExtensionContext, javaExecutabl
 
 /**
  * Starts the client and connects it to the language server
- * @param context
- * @param port
+ * @param context The extension context
+ * @param port The port number the server is running on
  */
 async function runClient(context: vscode.ExtensionContext, port: number) {
     const serverOptions: ServerOptions = () => {
@@ -310,7 +314,7 @@ async function runClient(context: vscode.ExtensionContext, port: number) {
 
 /**
  * Stops the LiquidJava extension
- * @param reason
+ * @param reason The reason for stopping the extension
  */
 async function stopExtension(reason: string) {
     if (!client && !serverProcess && !socket) {
@@ -345,7 +349,7 @@ async function stopExtension(reason: string) {
 
 /**
  * Handles LiquidJava diagnostics received from the language server
- * @param diagnostics
+ * @param diagnostics The array of diagnostics received
  */
 function handleLJDiagnostics(diagnostics: LJDiagnostic[]) {
     const containsError = diagnostics.some(d => d.category === "error");
@@ -360,7 +364,7 @@ function handleLJDiagnostics(diagnostics: LJDiagnostic[]) {
 
 /**
  * Handles active file change events
- * @param editor 
+ * @param editor The active text editor
  */
 function handleActiveFileChange(editor: vscode.TextEditor) {
     currentFile = editor.document.uri.fsPath;

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -9,7 +9,8 @@ import { connectToPort, findJavaExecutable, getAvailablePort, killProcess } from
 import { SERVER_JAR, DEBUG_MODE, DEBUG_PORT } from "./constants";
 import { LiquidJavaWebviewProvider } from "./webview/provider";
 import { LJDiagnostic } from "./types";
-import { createMermaidDiagram } from "./fsm";
+import { createMermaidDiagram } from "./webview/fsm";
+import { StateMachine } from "./types/fsm";
 
 let serverProcess: child_process.ChildProcess;
 let client: LanguageClient;
@@ -20,6 +21,7 @@ let statusBarItem: vscode.StatusBarItem;
 let currentDiagnostics: LJDiagnostic[];
 let webviewProvider: LiquidJavaWebviewProvider;
 let currentFile: string | undefined;
+let currentStateMachine: StateMachine | undefined;
 
 /**
  * Activates the LiquidJava extension
@@ -132,6 +134,7 @@ function initWebview(context: vscode.ExtensionContext) {
             if (message.type === "ready") {
                 webviewProvider.sendMessage({ type: "file", file: currentFile });
                 webviewProvider.sendMessage({ type: "diagnostics", diagnostics: currentDiagnostics });
+                if (currentStateMachine) webviewProvider.sendMessage({ type: "fsm", sm: currentStateMachine });
             }
         })
     );
@@ -183,9 +186,9 @@ function initFileEvents(context: vscode.ExtensionContext) {
 async function requestStateMachine(document: vscode.TextDocument) {
     const sm: StateMachine = await client?.sendRequest("liquidjava/fsm", { uri: document.uri.toString() });
     if (!sm) return;
- 
-    const diagram = createMermaidDiagram(sm);
-    console.log(diagram);
+
+    webviewProvider?.sendMessage({ type: "fsm", sm });
+    currentStateMachine = sm;
 }
 
 /**

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -9,6 +9,7 @@ import { connectToPort, findJavaExecutable, getAvailablePort, killProcess } from
 import { SERVER_JAR, DEBUG_MODE, DEBUG_PORT } from "./constants";
 import { LiquidJavaWebviewProvider } from "./webview/provider";
 import { LJDiagnostic } from "./types";
+import { createMermaidDiagram } from "./fsm";
 
 let serverProcess: child_process.ChildProcess;
 let client: LanguageClient;
@@ -22,22 +23,18 @@ let currentFile: string | undefined;
 
 /**
  * Activates the LiquidJava extension
- * @param context The extension context
+ * @param context
  */
 export async function activate(context: vscode.ExtensionContext) {
     initLogging(context);
     initStatusBar(context);
     initCommandPalette(context);
     initWebview(context);
+    initFileEvents(context);
     initHover();
 
     logger.client.info("Activating LiquidJava extension...");
     
-    const activeEditor = vscode.window.activeTextEditor;
-    if (activeEditor && activeEditor.document.languageId === "java") {
-        currentFile = activeEditor.document.uri.fsPath;
-        webviewProvider?.sendMessage({ type: "file", file: currentFile });
-    }
     await applyItalicOverlay();
 
     // find java executable path
@@ -69,7 +66,7 @@ export async function deactivate() {
 
 /**
  * Initializes logging for the extension with an output channel
- * @param context The extension context
+ * @param context
  */
 function initLogging(context: vscode.ExtensionContext) {
     outputChannel = vscode.window.createOutputChannel("LiquidJava");
@@ -81,7 +78,7 @@ function initLogging(context: vscode.ExtensionContext) {
 
 /**
  * Initializes the status bar for the extension
- * @param context The extension context
+ * @param context
  */
 function initStatusBar(context: vscode.ExtensionContext) {
     statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);
@@ -94,7 +91,7 @@ function initStatusBar(context: vscode.ExtensionContext) {
 
 /**
  * Initializes the command palette for the extension
- * @param context The extension context
+ * @param context
  */
 function initCommandPalette(context: vscode.ExtensionContext) {
     context.subscriptions.push(
@@ -113,7 +110,7 @@ function initCommandPalette(context: vscode.ExtensionContext) {
 
 /**
  * Initializes the webview panel for the extension
- * @param context The extension context
+ * @param context
  */
 function initWebview(context: vscode.ExtensionContext) {
     webviewProvider = new LiquidJavaWebviewProvider(context.extensionUri);
@@ -135,15 +132,6 @@ function initWebview(context: vscode.ExtensionContext) {
             if (message.type === "ready") {
                 webviewProvider.sendMessage({ type: "file", file: currentFile });
                 webviewProvider.sendMessage({ type: "diagnostics", diagnostics: currentDiagnostics });
-            }
-        })
-    );
-    // listen for active text editor changes
-    context.subscriptions.push(
-        vscode.window.onDidChangeActiveTextEditor(editor => {
-            if (editor && editor.document.languageId === "java") {
-                currentFile = editor.document.uri.fsPath;
-                webviewProvider?.sendMessage({ type: "file", file: currentFile });
             }
         })
     );
@@ -172,9 +160,37 @@ function initHover() {
     });
 }
 
+
+/**
+ * Initializes file system event listeners
+ * @param context
+ */
+function initFileEvents(context: vscode.ExtensionContext) {
+    // listen for active text editor changes
+    context.subscriptions.push(
+        vscode.window.onDidChangeActiveTextEditor(editor => {
+            if (!editor || editor.document.languageId !== "java") return;
+            handleActiveFileChange(editor);
+            
+        }),
+        vscode.workspace.onDidSaveTextDocument(document => {
+            if (document.uri.scheme !== 'file' || document.languageId !== "java") return;
+            requestStateMachine(document)
+        })
+    );
+}
+
+async function requestStateMachine(document: vscode.TextDocument) {
+    const sm: StateMachine = await client?.sendRequest("liquidjava/fsm", { uri: document.uri.toString() });
+    if (!sm) return;
+ 
+    const diagram = createMermaidDiagram(sm);
+    console.log(diagram);
+}
+
 /**
  * Updates the status bar with the current state
- * @param state The state of the status bar: "loading", "stopped", "passed" or "failed"
+ * @param state
  */
 function updateStatusBar(state: "loading" | "stopped" | "passed" | "failed") {
     const icons = {
@@ -190,8 +206,8 @@ function updateStatusBar(state: "loading" | "stopped" | "passed" | "failed") {
 
 /**
  * Runs the LiquidJava language server
- * @param context The extension context
- * @param javaExecutablePath The path to the Java executable
+ * @param context
+ * @param javaExecutablePath
  * @returns A promise to the port number the server is running on
  */
 async function runLanguageServer(context: vscode.ExtensionContext, javaExecutablePath: string): Promise<number> {
@@ -230,8 +246,8 @@ async function runLanguageServer(context: vscode.ExtensionContext, javaExecutabl
 
 /**
  * Starts the client and connects it to the language server
- * @param context The extension context
- * @param port The port the server is running on
+ * @param context
+ * @param port
  */
 async function runClient(context: vscode.ExtensionContext, port: number) {
     const serverOptions: ServerOptions = () => {
@@ -270,6 +286,11 @@ async function runClient(context: vscode.ExtensionContext, port: number) {
         client.onNotification("liquidjava/diagnostics", (diagnostics: LJDiagnostic[]) => {
             handleLJDiagnostics(diagnostics);
         });
+
+        const editor = vscode.window.activeTextEditor;
+        if (editor && editor.document.languageId === "java") {
+            handleActiveFileChange(editor);
+        }
     } catch (e) {
         vscode.window.showErrorMessage("LiquidJava failed to initialize: " + e.toString());
         logger.client.error("Failed to initialize: " + e.toString());
@@ -288,7 +309,7 @@ async function runClient(context: vscode.ExtensionContext, port: number) {
 
 /**
  * Stops the LiquidJava extension
- * @param reason The reason for stopping the extension
+ * @param reason
  */
 async function stopExtension(reason: string) {
     if (!client && !serverProcess && !socket) {
@@ -323,7 +344,7 @@ async function stopExtension(reason: string) {
 
 /**
  * Handles LiquidJava diagnostics received from the language server
- * @param diagnostics The LiquidJava diagnostics
+ * @param diagnostics
  */
 function handleLJDiagnostics(diagnostics: LJDiagnostic[]) {
     const containsError = diagnostics.some(d => d.category === "error");
@@ -334,4 +355,14 @@ function handleLJDiagnostics(diagnostics: LJDiagnostic[]) {
     }
     webviewProvider?.sendMessage({ type: "diagnostics", diagnostics });
     currentDiagnostics = diagnostics;
+}
+
+/**
+ * Handles active file change events
+ * @param editor 
+ */
+function handleActiveFileChange(editor: vscode.TextEditor) {
+    currentFile = editor.document.uri.fsPath;
+    webviewProvider?.sendMessage({ type: "file", file: currentFile });
+    requestStateMachine(editor.document);
 }

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -185,8 +185,6 @@ function initFileEvents(context: vscode.ExtensionContext) {
 
 async function requestStateMachine(document: vscode.TextDocument) {
     const sm: StateMachine = await client?.sendRequest("liquidjava/fsm", { uri: document.uri.toString() });
-    if (!sm) return;
-
     webviewProvider?.sendMessage({ type: "fsm", sm });
     currentStateMachine = sm;
 }

--- a/client/src/fsm.ts
+++ b/client/src/fsm.ts
@@ -1,0 +1,22 @@
+
+/**
+ * Converts a StateMachine object to a Mermaid state diagram string
+ * @param sm 
+ * @returns Mermaid diagram string
+ */
+export function createMermaidDiagram(sm: StateMachine): string {
+    const lines: string[] = [];
+
+    // header
+    lines.push('stateDiagram-v2');
+    
+    // initial state
+    lines.push(`    [*] --> ${sm.initial}`);
+    
+    // transitions
+    sm.transitions.forEach(transition => {
+        lines.push(`    ${transition.from} --> ${transition.to} : ${transition.on}`);
+    });
+    
+    return lines.join('\n');
+}

--- a/client/src/types/fsm.ts
+++ b/client/src/types/fsm.ts
@@ -2,5 +2,5 @@ export type StateMachine = {
     className: string;
     initial: string;
     states: string[];
-    transitions: { from: string; to: string; on: string }[];
+    transitions: { from: string; to: string; label: string }[];
 };

--- a/client/src/types/fsm.ts
+++ b/client/src/types/fsm.ts
@@ -1,4 +1,4 @@
-type StateMachine = {
+export type StateMachine = {
     className: string;
     initial: string;
     states: string[];

--- a/client/src/types/fsm.ts
+++ b/client/src/types/fsm.ts
@@ -1,0 +1,6 @@
+type StateMachine = {
+    className: string;
+    initial: string;
+    states: string[];
+    transitions: { from: string; to: string; on: string }[];
+};

--- a/client/src/webview/fsm.ts
+++ b/client/src/webview/fsm.ts
@@ -1,3 +1,4 @@
+import { StateMachine } from "../types/fsm";
 
 /**
  * Converts a StateMachine object to a Mermaid state diagram string
@@ -8,6 +9,9 @@ export function createMermaidDiagram(sm: StateMachine): string {
     const lines: string[] = [];
 
     // header
+    lines.push('---');
+    lines.push(`title: ${sm.className}`);
+    lines.push('---');
     lines.push('stateDiagram-v2');
     
     // initial state

--- a/client/src/webview/fsm.ts
+++ b/client/src/webview/fsm.ts
@@ -19,7 +19,7 @@ export function createMermaidDiagram(sm: StateMachine): string {
     
     // transitions
     sm.transitions.forEach(transition => {
-        lines.push(`    ${transition.from} --> ${transition.to} : ${transition.on}`);
+        lines.push(`    ${transition.from} --> ${transition.to} : ${transition.label}`);
     });
     
     return lines.join('\n');

--- a/client/src/webview/html.ts
+++ b/client/src/webview/html.ts
@@ -1,6 +1,8 @@
 import * as vscode from "vscode";
 import { getStyles } from "./styles";
 
+const MERMAID_CDN = "https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs";
+
 /**
  * Generates the HTML content for the webview
  * @param webview
@@ -18,12 +20,25 @@ export function getHtml(webview: vscode.Webview, extensionUri: vscode.Uri): stri
             <meta charset="utf-8">
             <meta
                 http-equiv="Content-Security-Policy"
-                content="default-src 'none'; style-src ${cspSource} 'unsafe-inline'; script-src 'nonce-${nonce}';"
+                content="default-src 'none'; style-src ${cspSource} 'unsafe-inline'; script-src 'nonce-${nonce}' https://cdn.jsdelivr.net; connect-src https://cdn.jsdelivr.net;"
             >
             <style>${getStyles()}</style>
         </head>
         <body>
             <div id="root"></div>
+            <script nonce="${nonce}" type="module">
+                import mermaid from '${MERMAID_CDN}';
+                mermaid.initialize({
+                    startOnLoad: false,
+                    theme: document.body.classList.contains('vscode-light') ? 'default' : 'dark',
+                    securityLevel: 'loose',
+                    flowchart: {
+                        useMaxWidth: true,
+                        htmlLabels: true
+                    }
+                });
+                window.mermaid = mermaid;
+            </script>
             <script nonce="${nonce}" src="${scriptUri}"></script>
         </body>
         </html>

--- a/client/src/webview/main.ts
+++ b/client/src/webview/main.ts
@@ -1,6 +1,6 @@
 import { getScript } from "./script";
 
-// Entry point for the webview
+// webview entry point
 
 declare function acquireVsCodeApi(): any;
 declare const document: any;

--- a/client/src/webview/renderers/diagnostics/utils.ts
+++ b/client/src/webview/renderers/diagnostics/utils.ts
@@ -33,12 +33,12 @@ export function renderTranslationTable(translationTable: TranslationTable): stri
     
     return /*html*/`
         <div class="translation-table">
-            <h3>Translation Table</h3>
+            <h3>Context Variables</h3>
             <table>
                 <thead>
                     <tr>
                         <th>Variable</th>
-                        <th>Code</th>
+                        <th>Source</th>
                         <th>Location</th>
                     </tr>
                 </thead>

--- a/client/src/webview/renderers/diagram.ts
+++ b/client/src/webview/renderers/diagram.ts
@@ -10,7 +10,7 @@ export function renderStateMachineView(sm: StateMachine, diagram: string): strin
                 <p><strong>States:</strong> ${sm.states.join(', ')}</p>
                 <p><strong>Initial state:</strong> ${sm.initial}</p>
                 <p><strong>Number of states:</strong> ${sm.states.length}</p>
-                <p><strong>Number of transitions:</strong> ${sm.transitions.length}</p>
+                <p><strong>Number of transitions:</strong> ${sm.transitions.length + 1}</p>
             </div>
         </div>
     `;

--- a/client/src/webview/renderers/diagram.ts
+++ b/client/src/webview/renderers/diagram.ts
@@ -1,0 +1,17 @@
+import { StateMachine } from "../../types/fsm";
+
+export function getDiagramView(diagram: string, sm: StateMachine): string {
+    return /*html*/`
+        <div class="diagram-section">
+            <div class="diagram-container">
+                <pre class="mermaid">${diagram}</pre>
+            </div>
+            <div>
+                <p><strong>States:</strong> ${sm.states.join(', ')}</p>
+                <p><strong>Initial state:</strong> ${sm.initial}</p>
+                <p><strong>Number of states:</strong> ${sm.states.length}</p>
+                <p><strong>Number of transitions:</strong> ${sm.transitions.length}</p>
+            </div>
+        </div>
+    `;
+}

--- a/client/src/webview/renderers/diagram.ts
+++ b/client/src/webview/renderers/diagram.ts
@@ -1,6 +1,6 @@
 import { StateMachine } from "../../types/fsm";
 
-export function getDiagramView(diagram: string, sm: StateMachine): string {
+export function renderStateMachineView(sm: StateMachine, diagram: string): string {
     return /*html*/`
         <div class="diagram-section">
             <div class="diagram-container">

--- a/client/src/webview/script.ts
+++ b/client/src/webview/script.ts
@@ -4,7 +4,7 @@ import { getCorrectView } from "./renderers/correct";
 import { getLoadingView } from "./renderers/loading";
 import { getErrorsView } from "./renderers/diagnostics/errors";
 import { getWarningsView } from "./renderers/diagnostics/warnings";
-import { getDiagramView } from "./renderers/diagram";
+import { renderStateMachineView } from "./renderers/diagram";
 import { StateMachine } from "../types/fsm";
 import { createMermaidDiagram } from "./fsm";
 
@@ -21,7 +21,7 @@ export function getScript(vscode: any, document: any, window: any) {
     let showAllDiagnostics = false;
     let currentFile: string | undefined;
     let expandedErrors = new Set<number>();
-    let stateMachine = '';
+    let stateMachineView = '';
 
     // initial state
     root.innerHTML = getLoadingView();
@@ -108,9 +108,14 @@ export function getScript(vscode: any, document: any, window: any) {
             currentFile = msg.file;
             if (!showAllDiagnostics) updateView();
         } else if (msg.type === 'fsm') {
+            if (!msg.sm) {
+                stateMachineView = '';
+                updateView();
+                return;
+            }
             const sm = msg.sm as StateMachine;
             const diagram = createMermaidDiagram(sm);
-            stateMachine = diagram ? getDiagramView(diagram, sm) : '';
+            stateMachineView = renderStateMachineView(sm, diagram);
             updateView();
         }
     });  
@@ -132,12 +137,10 @@ export function getScript(vscode: any, document: any, window: any) {
     function updateView() {
         let mainView = fileErrors.length > 0 ? getErrorsView(fileErrors, showAllDiagnostics, currentFile, expandedErrors) : getCorrectView(showAllDiagnostics);
         let warningsView = fileWarnings.length > 0 ? getWarningsView(fileWarnings, showAllDiagnostics, currentFile) : '';
-        root.innerHTML = mainView + warningsView + stateMachine;
+        root.innerHTML = mainView + warningsView + stateMachineView;
         
         // re-render mermaid diagram after DOM update
-        if (stateMachine) {
-            renderMermaidDiagram();
-        }
+        if (stateMachineView) renderMermaidDiagram();
     }
 }
 

--- a/client/src/webview/script.ts
+++ b/client/src/webview/script.ts
@@ -4,6 +4,9 @@ import { getCorrectView } from "./renderers/correct";
 import { getLoadingView } from "./renderers/loading";
 import { getErrorsView } from "./renderers/diagnostics/errors";
 import { getWarningsView } from "./renderers/diagnostics/warnings";
+import { getDiagramView } from "./renderers/diagram";
+import { StateMachine } from "../types/fsm";
+import { createMermaidDiagram } from "./fsm";
 
 /**
  * Initializes the webview script
@@ -18,6 +21,7 @@ export function getScript(vscode: any, document: any, window: any) {
     let showAllDiagnostics = false;
     let currentFile: string | undefined;
     let expandedErrors = new Set<number>();
+    let stateMachine = '';
 
     // initial state
     root.innerHTML = getLoadingView();
@@ -103,13 +107,37 @@ export function getScript(vscode: any, document: any, window: any) {
         } else if (msg.type === 'file') {
             currentFile = msg.file;
             if (!showAllDiagnostics) updateView();
+        } else if (msg.type === 'fsm') {
+            const sm = msg.sm as StateMachine;
+            const diagram = createMermaidDiagram(sm);
+            stateMachine = diagram ? getDiagramView(diagram, sm) : '';
+            updateView();
         }
-    });
+    });  
+
+    async function renderMermaidDiagram() {
+        const mermaid = (window as any).mermaid;
+        if (!mermaid) return;
+
+        const mermaidElements = document.querySelectorAll('.mermaid');
+        if (mermaidElements.length === 0) return;
+
+        try {
+            await mermaid.run({ nodes: mermaidElements });
+        } catch (e) {
+            console.error('Failed to render Mermaid diagram:', e);
+        }
+    }
 
     function updateView() {
         let mainView = fileErrors.length > 0 ? getErrorsView(fileErrors, showAllDiagnostics, currentFile, expandedErrors) : getCorrectView(showAllDiagnostics);
         let warningsView = fileWarnings.length > 0 ? getWarningsView(fileWarnings, showAllDiagnostics, currentFile) : '';
-        root.innerHTML = mainView + warningsView;
+        root.innerHTML = mainView + warningsView + stateMachine;
+        
+        // re-render mermaid diagram after DOM update
+        if (stateMachine) {
+            renderMermaidDiagram();
+        }
     }
 }
 

--- a/client/src/webview/styles.ts
+++ b/client/src/webview/styles.ts
@@ -30,7 +30,7 @@ export function getStyles(): string {
             overflow-x: auto;
         }
         strong {
-            display: block;
+            display: inline;
             margin-bottom: 0.5rem;
         }
         .container {
@@ -240,6 +240,31 @@ export function getStyles(): string {
             border-radius: 3px;
             font-family: var(--vscode-editor-font-family);
             font-size: 0.9em;
+        }
+        .diagram-section {
+            margin-bottom: 1.5rem;
+            padding-bottom: 1rem;
+            border-bottom: 1px solid var(--vscode-panel-border);
+        }
+        .diagram-section h2 {
+            margin-bottom: 0.5rem;
+        }
+        .diagram-container {
+            background-color: var(--vscode-editor-background);
+            border-radius: 4px;
+            padding: 1rem;
+            overflow-x: auto;
+        }
+        .diagram-container .mermaid {
+            display: flex;
+            justify-content: center;
+        }
+        .diagram-container .mermaid svg {
+            max-width: 100%;
+            height: auto;
+        }
+        .mermaid .statediagramTitleText {
+            font-size: 22px!important;
         }
     `;
 }

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -173,7 +173,7 @@
 		<dependency>
 			<groupId>io.github.liquid-java</groupId>
 			<artifactId>liquidjava-verifier</artifactId>
-			<version>0.0.10</version>
+			<version>0.0.11</version>
 		</dependency>
 		<dependency>
 			<groupId>tools.aqua</groupId>

--- a/server/src/main/java/LJDiagnosticsService.java
+++ b/server/src/main/java/LJDiagnosticsService.java
@@ -14,8 +14,8 @@ import org.eclipse.lsp4j.PublishDiagnosticsParams;
 import org.eclipse.lsp4j.services.TextDocumentService;
 import org.eclipse.lsp4j.services.WorkspaceService;
 
-import dtos.DiagnosticConverter;
 import liquidjava.diagnostics.LJDiagnostic;
+import utils.DiagnosticConverter;
 import utils.PathUtils;
 
 public class LJDiagnosticsService implements TextDocumentService, WorkspaceService {

--- a/server/src/main/java/LJLanguageServer.java
+++ b/server/src/main/java/LJLanguageServer.java
@@ -7,9 +7,14 @@ import org.eclipse.lsp4j.TextDocumentSyncKind;
 import org.eclipse.lsp4j.WorkspaceFoldersOptions;
 import org.eclipse.lsp4j.WorkspaceServerCapabilities;
 import org.eclipse.lsp4j.jsonrpc.services.JsonNotification;
+import org.eclipse.lsp4j.jsonrpc.services.JsonRequest;
 import org.eclipse.lsp4j.services.LanguageServer;
 import org.eclipse.lsp4j.services.TextDocumentService;
 import org.eclipse.lsp4j.services.WorkspaceService;
+
+import dtos.uri.Uri;
+import fsm.StateMachine;
+import fsm.StateMachineParser;
 
 public class LJLanguageServer implements LanguageServer {
 
@@ -75,5 +80,12 @@ public class LJLanguageServer implements LanguageServer {
     @JsonNotification("$/setTraceNotification")
     public void setTrace(Object params) {
         // suppress notification
+    }
+
+    @JsonRequest("liquidjava/fsm")
+    public CompletableFuture<StateMachine> fsm(Uri uri) {
+        return CompletableFuture.supplyAsync(() -> {
+            return StateMachineParser.parse(uri.uri());
+        });
     }
 }

--- a/server/src/main/java/dtos/uri/Uri.java
+++ b/server/src/main/java/dtos/uri/Uri.java
@@ -1,0 +1,3 @@
+package dtos.uri;
+
+public record Uri(String uri) {}

--- a/server/src/main/java/fsm/StateMachine.java
+++ b/server/src/main/java/fsm/StateMachine.java
@@ -1,0 +1,13 @@
+package fsm;
+
+import java.util.List;
+
+/**
+ * Represents a state machine
+ */
+public record StateMachine(
+    String className,
+    String initial,
+    List<String> states,
+    List<StateMachineTransition> transitions
+) { }

--- a/server/src/main/java/fsm/StateMachineParser.java
+++ b/server/src/main/java/fsm/StateMachineParser.java
@@ -63,7 +63,7 @@ public class StateMachineParser {
             } else {
                 return null;
             }
-            if (transitions == null) return null; // no transitions found
+            if (transitions.isEmpty()) return null; // no transitions found
             
             return new StateMachine(className, initial, states, transitions);
 

--- a/server/src/main/java/fsm/StateMachineParser.java
+++ b/server/src/main/java/fsm/StateMachineParser.java
@@ -24,7 +24,7 @@ public class StateMachineParser {
 
     /**
      * Parses a class or interface for the given uri and extracts the state machine information
-     * @param uri
+     * @param uri the document URI
      * @return StateMachine or null if none found
      */
     public static StateMachine parse(String uri) {
@@ -75,7 +75,7 @@ public class StateMachineParser {
 
     /**
      * Finds the first class or interface in the model (we assume only one per file)
-     * @param model
+     * @param model the CtModel
      * @return CtType or null if none found
      */
     private static CtType<?> getType(CtModel model) {
@@ -90,7 +90,7 @@ public class StateMachineParser {
     /**
      * Gets the simple name from a class or interface
      * Uses name from ExternalRefinementsFor if present, otherwise uses class or interface name
-     * @param ctType
+     * @param ctType the CtType (class or interface)
      * @return class name
      */
     private static String getClassName(CtType<?> ctType) {
@@ -105,7 +105,7 @@ public class StateMachineParser {
 
     /**
      * Gets the possible states from a class or interface
-     * @param ctType
+     * @param ctType the CtType (class or interface)
      * @return list of states
      */
     private static List<String> getStates(CtType<?> ctType) {
@@ -121,7 +121,8 @@ public class StateMachineParser {
     /**
      * Gets the initial state from a class
      * If not explicitely defined, uses the first state in the state set
-     * @param ctClass
+     * @param ctClass the CtClass
+     * @param states the list of states
      * @return initial state
      */
     private static String getInitialStateFromClass(CtClass<?> ctClass, List<String> states) {
@@ -142,8 +143,8 @@ public class StateMachineParser {
     /**
      * Gets the initial state from an interface
      * If not explicitely defined, uses the first state in the state set
-     * @param ctInterface
-     * @param className
+     * @param ctInterface the CtInterface
+     * @param className the class name
      * @return initial state
      */
     private static String getInitialStateFromInterface(CtInterface<?> ctInterface, String className, List<String> states) {
@@ -165,8 +166,8 @@ public class StateMachineParser {
 
     /**
      * Gets transitions from a class
-     * @param ctClass
-     * @param states
+     * @param ctClass the CtClass
+     * @param states the list of states
      * @return list of StateMachineTransition
      */
     private static List<StateMachineTransition> getTransitionsFromClass(CtClass<?> ctClass, List<String> states) {
@@ -185,9 +186,9 @@ public class StateMachineParser {
 
     /**
      * Gets transitions from an interface
-     * @param ctInterface
-     * @param className
-     * @param states
+     * @param ctInterface the CtInterface
+     * @param className the class name
+     * @param states the list of states
      * @return list of StateMachineTransition
      */
     private static List<StateMachineTransition> getTransitionsFromInterface(CtInterface<?> ctInterface, String className, List<String> states) {
@@ -207,9 +208,9 @@ public class StateMachineParser {
 
     /**
      * Gets transitions from the given annotation
-     * @param ann
-     * @param method
-     * @param states
+     * @param ann the CtAnnotation
+     * @param method the method name
+     * @param states the list of states
      * @return list of StateMachineTransition
      */
     private static List<StateMachineTransition> getTransitions(CtAnnotation<?> ann, String method, List<String> states) {
@@ -242,8 +243,8 @@ public class StateMachineParser {
 
     /**
      * Parses a state expression and returns the list of states
-     * @param expr
-     * @param states
+     * @param expr the expression
+     * @param states the list of possible states
      * @return list of states
      */
     private static List<String> parseStateExpression(String expr, List<String> states) {
@@ -254,8 +255,8 @@ public class StateMachineParser {
 
     /**
      * Gets state names from an expression AST recursively
-     * @param expr
-     * @param states
+     * @param expr the expression
+     * @param states the list of possible states
      * @return list of states
      */
     private static List<String> getStateExpressions(Expression expr, List<String> states) {

--- a/server/src/main/java/fsm/StateMachineParser.java
+++ b/server/src/main/java/fsm/StateMachineParser.java
@@ -218,7 +218,7 @@ public class StateMachineParser {
         String to = ann.getValueAsString("to");
 
         // if has from but not to, to is the same as from (self-loop)
-        if (from != null && to == null) {
+        if (!from.isEmpty() && to.isEmpty()) {
             to = from;
         }
 
@@ -227,7 +227,7 @@ public class StateMachineParser {
         List<String> toStates = parseStateExpression(to, states);
 
         // if no from states, use all states
-        if (fromStates.isEmpty() && to != null) {
+        if (fromStates.isEmpty()) {
             fromStates = new ArrayList<>(states);
         }
 

--- a/server/src/main/java/fsm/StateMachineParser.java
+++ b/server/src/main/java/fsm/StateMachineParser.java
@@ -1,0 +1,253 @@
+package fsm;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+
+import liquidjava.utils.Utils;
+import spoon.Launcher;
+import spoon.reflect.CtModel;
+import spoon.reflect.declaration.CtAnnotation;
+import spoon.reflect.declaration.CtClass;
+import spoon.reflect.declaration.CtConstructor;
+import spoon.reflect.declaration.CtInterface;
+import spoon.reflect.declaration.CtMethod;
+import spoon.reflect.declaration.CtType;
+
+public class StateMachineParser {
+
+    private static final String STATE_SET_ANNOTATION = "StateSet";
+    private static final String STATE_REFINEMENT_ANNOTATION = "StateRefinement";
+    private static final String EXTERNAL_REFINEMENTS_FOR_ANNOTATION = "ExternalRefinementsFor";
+
+    /**
+     * Parses a class or interface for the given uri and extracts the state machine information
+     * @param uri
+     * @return StateMachine or null if none found
+     */
+    public static StateMachine parse(String uri) {
+        try {
+            String filePath = new URI(uri).getPath();
+            Launcher launcher = new Launcher();
+            launcher.getEnvironment().setNoClasspath(true);
+            launcher.getEnvironment().setAutoImports(true);
+            launcher.addInputResource(filePath);
+            launcher.buildModel();
+            CtModel model = launcher.getModel();
+
+            // get class or interface
+            CtType<?> ctType = getType(model);
+            if (ctType == null) {
+                return null;
+            }
+
+            // extract class name and states
+            List<String> states = getStates(ctType);
+            String className = getClassName(ctType);
+
+            // extract initial state and transitions
+            String initial;
+            List<StateMachineTransition> transitions;
+            if (ctType instanceof CtClass<?> ctClass) {
+                initial = getInitialStateFromClass(ctClass, states);
+                transitions = getTransitionsFromClass(ctClass, states);
+            } else if (ctType instanceof CtInterface<?> ctInterface) {
+                initial = getInitialStateFromInterface(ctInterface, className, states);
+                transitions = getTransitionsFromInterface(ctInterface, className, states);
+            } else {
+                return null;
+            }
+            if (transitions == null) return null; // no transitions found
+            
+            return new StateMachine(className, initial, states, transitions);
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+    /**
+     * Finds the first class or interface in the model (we assume only one per file)
+     * @param model
+     * @return CtType or null if none found
+     */
+    private static CtType<?> getType(CtModel model) {
+        for (CtType<?> type : model.getAllTypes()) {
+            if (type instanceof CtClass<?> || type instanceof CtInterface<?>) {
+                return type;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Extracts the simple name from a class or interface
+     * Uses name from ExternalRefinementsFor if present, otherwise uses class or interface name
+     * @param ctType
+     * @return class name
+     */
+    private static String getClassName(CtType<?> ctType) {
+        for (CtAnnotation<?> annotation : ctType.getAnnotations()) {
+            if (annotation.getAnnotationType().getSimpleName().equals(EXTERNAL_REFINEMENTS_FOR_ANNOTATION)) {
+                String qualifiedName = (String) annotation.getValueAsObject("value");
+                return Utils.getSimpleName(qualifiedName);                
+            }
+        }
+        return ctType.getSimpleName();
+    }
+
+    /**
+     * Extracts the possible states from a class or interface
+     * @param ctType
+     * @return list of states
+     */
+    private static List<String> getStates(CtType<?> ctType) {
+        for (CtAnnotation<?> annotation : ctType.getAnnotations()) {
+            if (annotation.getAnnotationType().getSimpleName().equals(STATE_SET_ANNOTATION)) {
+                String[] stateArray = (String[]) annotation.getValueAsObject("value");
+                return List.of(stateArray);
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Extracts the initial state from a class
+     * If not explicitely defined, uses the first state in the state set
+     * @param ctClass
+     * @return initial state
+     */
+    private static String getInitialStateFromClass(CtClass<?> ctClass, List<String> states) {
+        for (CtConstructor<?> constructor : ctClass.getConstructors()) {
+            for (CtAnnotation<?> annotation : constructor.getAnnotations()) {
+                if (annotation.getAnnotationType().getSimpleName().equals(STATE_REFINEMENT_ANNOTATION)) {
+                    Object to = annotation.getValueAsObject("to");
+                    return normalizeState(to);
+                }
+            }
+        }
+        return states.isEmpty() ? null : states.getFirst();
+    }
+
+    /**
+     * Extracts the initial state from an interface
+     * If not explicitely defined, uses the first state in the state set
+     * @param ctInterface
+     * @param className
+     * @return initial state
+     */
+    private static String getInitialStateFromInterface(CtInterface<?> ctInterface, String className, List<String> states) {
+        for (CtMethod<?> method : ctInterface.getMethods()) {
+            if (method.getSimpleName().equals(className)) {
+                for (CtAnnotation<?> annotation : method.getAnnotations()) {
+                    if (annotation.getAnnotationType().getSimpleName().equals(STATE_REFINEMENT_ANNOTATION)) {
+                        Object to = annotation.getValueAsObject("to");
+                        return normalizeState(to);
+                    }
+                }
+            }
+        }
+        return states.isEmpty() ? null : states.getFirst();
+    }
+
+    /**
+     * Extracts transitions from a class
+     * @param ctClass
+     * @param states
+     * @return list of StateMachineTransition
+     */
+    private static List<StateMachineTransition> getTransitionsFromClass(CtClass<?> ctClass, List<String> states) {
+        List<StateMachineTransition> transitions = new ArrayList<>();
+        for (CtMethod<?> method : ctClass.getMethods()) {
+            for (CtAnnotation<?> annotation : method.getAnnotations()) {
+                if (annotation.getAnnotationType().getSimpleName().equals(STATE_REFINEMENT_ANNOTATION)) {
+                    List<StateMachineTransition> extracted = getTransitions(annotation, method.getSimpleName(), states);
+                    transitions.addAll(extracted);
+                }
+            }
+        }
+
+        return transitions;
+    }
+
+    /**
+     * Extracts transitions from an interface
+     * @param ctInterface
+     * @param className
+     * @param states
+     * @return list of StateMachineTransition
+     */
+    private static List<StateMachineTransition> getTransitionsFromInterface(CtInterface<?> ctInterface, String className, List<String> states) {
+        List<StateMachineTransition> transitions = new ArrayList<>();
+        for (CtMethod<?> method : ctInterface.getMethods()) {
+            if (method.getSimpleName().equals(className)) continue; // skip constructor method
+
+            for (CtAnnotation<?> annotation : method.getAnnotations()) {
+                if (annotation.getAnnotationType().getSimpleName().equals(STATE_REFINEMENT_ANNOTATION)) {
+                    List<StateMachineTransition> extracted = getTransitions(annotation, method.getSimpleName(), states);
+                    transitions.addAll(extracted);
+                }
+            }
+        }
+        return transitions;
+    }
+
+    /**
+     * Extracts transitions from the given annotation
+     * @param annotation
+     * @param methodName
+     * @param states
+     * @return list of StateMachineTransition
+     */
+    private static List<StateMachineTransition> getTransitions(CtAnnotation<?> annotation, String methodName, List<String> states) {
+        List<StateMachineTransition> transitions = new ArrayList<>();
+        String from = normalizeState(annotation.getValueAsObject("from"));
+        String to = normalizeState(annotation.getValueAsObject("to"));
+
+        // if has from but not to, to is the same as from (self-loop)
+        if (from != null && to == null) {
+            to = from;
+        }
+
+        // if from is !state, from is all states except state (multiple transitions)
+        if (from != null && from.startsWith("!")) {
+            String excludedState = from.substring(1);
+            if (states != null && to != null) {
+                for (String state : states) {
+                    if (!state.equals(excludedState)) {
+                        transitions.add(new StateMachineTransition(state, to, methodName));
+                    }
+                }
+            }
+            return transitions;
+        }
+
+        // if has to but not from, from is all states (multiple transitions)
+        if (to != null && from == null) {
+            if (states != null) {
+                for (String state : states) {
+                    transitions.add(new StateMachineTransition(state, to, methodName));
+                }
+            }
+            return transitions;
+        }
+
+        // normal transition
+        if (from != null && to != null) {
+            transitions.add(new StateMachineTransition(from, to, methodName));
+        }
+        return transitions;
+    }
+
+    /**
+     * Normalizes the state value by removing (this) and returning null if empty
+     * @param value
+     * @return normalized state
+     */
+    private static String normalizeState(Object value) {
+        if (value == null) return null;
+        String normalized = value.toString().replace("(this)", "");
+        return normalized.isEmpty() ? null : normalized;
+    }
+}

--- a/server/src/main/java/fsm/StateMachineParser.java
+++ b/server/src/main/java/fsm/StateMachineParser.java
@@ -4,6 +4,8 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 
+import liquidjava.rj_language.ast.*;
+import liquidjava.rj_language.parsing.RefinementsParser;
 import liquidjava.utils.Utils;
 import spoon.Launcher;
 import spoon.reflect.CtModel;
@@ -86,7 +88,7 @@ public class StateMachineParser {
     }
 
     /**
-     * Extracts the simple name from a class or interface
+     * Gets the simple name from a class or interface
      * Uses name from ExternalRefinementsFor if present, otherwise uses class or interface name
      * @param ctType
      * @return class name
@@ -102,7 +104,7 @@ public class StateMachineParser {
     }
 
     /**
-     * Extracts the possible states from a class or interface
+     * Gets the possible states from a class or interface
      * @param ctType
      * @return list of states
      */
@@ -117,7 +119,7 @@ public class StateMachineParser {
     }
 
     /**
-     * Extracts the initial state from a class
+     * Gets the initial state from a class
      * If not explicitely defined, uses the first state in the state set
      * @param ctClass
      * @return initial state
@@ -126,16 +128,19 @@ public class StateMachineParser {
         for (CtConstructor<?> constructor : ctClass.getConstructors()) {
             for (CtAnnotation<?> annotation : constructor.getAnnotations()) {
                 if (annotation.getAnnotationType().getSimpleName().equals(STATE_REFINEMENT_ANNOTATION)) {
-                    Object to = annotation.getValueAsObject("to");
-                    return normalizeState(to);
+                    String to = annotation.getValueAsString("to");
+                    List<String> parsedStates = parseStateExpression(to, states);
+                    if (!parsedStates.isEmpty()) {
+                        return parsedStates.getFirst();
+                    }
                 }
             }
         }
-        return states.isEmpty() ? null : states.getFirst();
+        return states.getFirst();
     }
 
     /**
-     * Extracts the initial state from an interface
+     * Gets the initial state from an interface
      * If not explicitely defined, uses the first state in the state set
      * @param ctInterface
      * @param className
@@ -146,8 +151,11 @@ public class StateMachineParser {
             if (method.getSimpleName().equals(className)) {
                 for (CtAnnotation<?> annotation : method.getAnnotations()) {
                     if (annotation.getAnnotationType().getSimpleName().equals(STATE_REFINEMENT_ANNOTATION)) {
-                        Object to = annotation.getValueAsObject("to");
-                        return normalizeState(to);
+                        String to = annotation.getValueAsString("to");
+                        List<String> parsedStates = parseStateExpression(to, states);
+                        if (!parsedStates.isEmpty()) {
+                            return parsedStates.getFirst();
+                        }
                     }
                 }
             }
@@ -156,7 +164,7 @@ public class StateMachineParser {
     }
 
     /**
-     * Extracts transitions from a class
+     * Gets transitions from a class
      * @param ctClass
      * @param states
      * @return list of StateMachineTransition
@@ -176,7 +184,7 @@ public class StateMachineParser {
     }
 
     /**
-     * Extracts transitions from an interface
+     * Gets transitions from an interface
      * @param ctInterface
      * @param className
      * @param states
@@ -198,60 +206,84 @@ public class StateMachineParser {
     }
 
     /**
-     * Extracts transitions from the given annotation
-     * @param annotation
-     * @param methodName
+     * Gets transitions from the given annotation
+     * @param ann
+     * @param method
      * @param states
      * @return list of StateMachineTransition
      */
-    private static List<StateMachineTransition> getTransitions(CtAnnotation<?> annotation, String methodName, List<String> states) {
+    private static List<StateMachineTransition> getTransitions(CtAnnotation<?> ann, String method, List<String> states) {
         List<StateMachineTransition> transitions = new ArrayList<>();
-        String from = normalizeState(annotation.getValueAsObject("from"));
-        String to = normalizeState(annotation.getValueAsObject("to"));
+        String from = ann.getValueAsString("from");
+        String to = ann.getValueAsString("to");
 
         // if has from but not to, to is the same as from (self-loop)
         if (from != null && to == null) {
             to = from;
         }
 
-        // if from is !state, from is all states except state (multiple transitions)
-        if (from != null && from.startsWith("!")) {
-            String excludedState = from.substring(1);
-            if (states != null && to != null) {
-                for (String state : states) {
-                    if (!state.equals(excludedState)) {
-                        transitions.add(new StateMachineTransition(state, to, methodName));
-                    }
-                }
-            }
-            return transitions;
+        // parse from and to expressions
+        List<String> fromStates = parseStateExpression(from, states);
+        List<String> toStates = parseStateExpression(to, states);
+
+        // if no from states, use all states
+        if (fromStates.isEmpty() && to != null) {
+            fromStates = new ArrayList<>(states);
         }
 
-        // if has to but not from, from is all states (multiple transitions)
-        if (to != null && from == null) {
-            if (states != null) {
-                for (String state : states) {
-                    transitions.add(new StateMachineTransition(state, to, methodName));
-                }
+        // create transitions for each combination of from and to states
+        for (String fromState : fromStates) {
+            for (String toState : toStates) {
+                transitions.add(new StateMachineTransition(fromState, toState, method));
             }
-            return transitions;
-        }
-
-        // normal transition
-        if (from != null && to != null) {
-            transitions.add(new StateMachineTransition(from, to, methodName));
         }
         return transitions;
     }
 
     /**
-     * Normalizes the state value by removing (this) and returning null if empty
-     * @param value
-     * @return normalized state
+     * Parses a state expression and returns the list of states
+     * @param expr
+     * @param states
+     * @return list of states
      */
-    private static String normalizeState(Object value) {
-        if (value == null) return null;
-        String normalized = value.toString().replace("(this)", "");
-        return normalized.isEmpty() ? null : normalized;
+    private static List<String> parseStateExpression(String expr, List<String> states) {
+        if (expr == null || expr.isEmpty()) return new ArrayList<>();
+        Expression ast = RefinementsParser.createAST(expr, "");
+        return getStateExpressions(ast, states);
+    }
+
+    /**
+     * Gets state names from an expression AST recursively
+     * @param expr
+     * @param states
+     * @return list of states
+     */
+    private static List<String> getStateExpressions(Expression expr, List<String> states) {
+        List<String> stateExpressions = new ArrayList<>();
+        if (expr instanceof Var var) {
+            stateExpressions.add(var.getName());
+        } else if (expr instanceof FunctionInvocation func) {
+            stateExpressions.add(func.getName());
+        } else if (expr instanceof GroupExpression group) {
+            stateExpressions.addAll(getStateExpressions(group.getExpression(), states));
+        } else if (expr instanceof BinaryExpression bin) {
+            String op = bin.getOperator();
+            if (op.equals("||")) {
+                // combine states from both operands
+                stateExpressions.addAll(getStateExpressions(bin.getFirstOperand(), states));
+                stateExpressions.addAll(getStateExpressions(bin.getSecondOperand(), states));
+            }
+        } else if (expr instanceof UnaryExpression unary) {
+            if (unary.getOp().equals("!")) {
+                // all except those in the expression
+                List<String> negatedStates = getStateExpressions(unary.getExpression(), states);
+                for (String state : states) {
+                    if (!negatedStates.contains(state)) {
+                        stateExpressions.add(state);
+                    }
+                }
+            }
+        }
+        return stateExpressions;
     }
 }

--- a/server/src/main/java/fsm/StateMachineParser.java
+++ b/server/src/main/java/fsm/StateMachineParser.java
@@ -43,6 +43,10 @@ public class StateMachineParser {
 
             // extract class name and states
             List<String> states = getStates(ctType);
+            if (states == null || states.isEmpty()) {
+                return null;
+            }
+
             String className = getClassName(ctType);
 
             // extract initial state and transitions

--- a/server/src/main/java/fsm/StateMachineTransition.java
+++ b/server/src/main/java/fsm/StateMachineTransition.java
@@ -1,0 +1,6 @@
+package fsm;
+
+/**
+ * Represents a transition in a state machine
+ */
+public record StateMachineTransition(String from, String to, String on) {}

--- a/server/src/main/java/fsm/StateMachineTransition.java
+++ b/server/src/main/java/fsm/StateMachineTransition.java
@@ -3,4 +3,4 @@ package fsm;
 /**
  * Represents a transition in a state machine
  */
-public record StateMachineTransition(String from, String to, String on) {}
+public record StateMachineTransition(String from, String to, String label) {}

--- a/server/src/main/java/utils/DiagnosticConverter.java
+++ b/server/src/main/java/utils/DiagnosticConverter.java
@@ -1,6 +1,6 @@
 
 
-package dtos;
+package utils;
 
 import dtos.diagnostics.LJDiagnosticDTO;
 import dtos.errors.ArgumentMismatchErrorDTO;


### PR DESCRIPTION
This PR adds a state machine diagram to the webview that updates in real-time, rendered using [Mermaid](https://mermaid.ai).

<img width="1033" height="814" alt="image" src="https://github.com/user-attachments/assets/c1f6a572-0168-431e-8167-893236301da8" />

## How it works

- When a document is opened or modified, the client sends a `liquidjava/fsm` LSP request to the language server with the document uri
- The language server calls the `StateMachineParser` which uses Spoon to analyze the AST of the class or interface in the file, extracting:
  - Target class name (declared in `@ExternalRefinementsFor` or own name if not present)
  - Initial state
  - State set
  - State transitions
- The extraction of the state transitions relies on the LiquidJava parser to parse expressions within the `@StateRefinement` annotations
- If no states or transitions are found, the server returns `null` and nothing happens in the client
- Otherwise, the client sends this information to the webview which creates a Mermaid diagram using it and renders it as HTML below the diagnostic information

### Handled cases

- `state1 || state2` → separate transitions
- `!state` → all states except `state`
- `from=state, to=state` or `from=state` → self-loop
- `to=state` → all states contain a transition to `state`


