### PR TITLE
Autocomplete for Refinements

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -8,6 +8,7 @@ import { registerStatusBar, updateStatusBar } from "./services/status-bar";
 import { registerWebview } from "./services/webview";
 import { registerHover } from "./services/hover";
 import { registerEvents } from "./services/events";
+import { registerAutocomplete } from "./services/autocomplete";
 import { runLanguageServer, stopLanguageServer } from "./lsp/server";
 import { runClient, stopClient } from "./lsp/client";
 
@@ -21,6 +22,7 @@ export async function activate(context: vscode.ExtensionContext) {
     registerCommands(context);
     registerWebview(context);
     registerEvents(context);
+    registerAutocomplete(context);
     registerHover();
 
     extension.logger.client.info("Activating LiquidJava extension...");

--- a/client/src/lsp/client.ts
+++ b/client/src/lsp/client.ts
@@ -6,6 +6,8 @@ import { updateStatusBar } from '../services/status-bar';
 import { handleLJDiagnostics } from '../services/diagnostics';
 import { onActiveFileChange } from '../services/events';
 import type { LJDiagnostic } from "../types/diagnostics";
+import { ContextHistory } from '../types/context';
+import { handleContextHistory } from '../services/context';
 
 /**
  * Starts the client and connects it to the language server
@@ -40,6 +42,10 @@ export async function runClient(context: vscode.ExtensionContext, port: number) 
         
         extension.client.onNotification("liquidjava/diagnostics", (diagnostics: LJDiagnostic[]) => {
             handleLJDiagnostics(diagnostics);
+        });
+
+        extension.client.onNotification("liquidjava/context", (contextHistory: ContextHistory) => {
+            handleContextHistory(contextHistory);
         });
 
         const editor = vscode.window.activeTextEditor;

--- a/client/src/services/autocomplete.ts
+++ b/client/src/services/autocomplete.ts
@@ -24,7 +24,7 @@ export function registerAutocomplete(context: vscode.ExtensionContext) {
 function getContextCompletionItems(context: ContextHistory, file: string, nextChar: string): vscode.CompletionItem[] {
     const variablesInScope = getVariablesInScope(file, extension.selection);
     const triggerParameterHints = nextChar !== "(";
-    const variableItems = getVariableCompletionItems([...variablesInScope, ...context.instanceVars, ...context.globalVars]);
+    const variableItems = getVariableCompletionItems([...variablesInScope, ...context.globalVars]); // not including instance vars
     const ghostItems = getGhostCompletionItems(context.ghosts, triggerParameterHints);
     const aliasItems = getAliasCompletionItems(context.aliases, triggerParameterHints);
     const keywordItems = getKeywordsCompletionItems(triggerParameterHints);
@@ -34,7 +34,7 @@ function getContextCompletionItems(context: ContextHistory, file: string, nextCh
     const uniqueItems = new Map<string, vscode.CompletionItem>();
     allItems.forEach(item => {
         const label = typeof item.label === "string" ? item.label : item.label.label;
-        if (!uniqueItems.has(label) && !label.startsWith("this#")) uniqueItems.set(label, item);
+        if (!uniqueItems.has(label)) uniqueItems.set(label, item);
     });
     return Array.from(uniqueItems.values());
 }
@@ -45,7 +45,6 @@ function getVariableCompletionItems(variables: Variable[]): vscode.CompletionIte
         const codeBlocks: string[] = [];
         if (variable.mainRefinement !== "true") codeBlocks.push(`@Refinement("${variable.mainRefinement}")`);
         codeBlocks.push(varSig);
-
         return createCompletionItem({
             name: variable.name,
             kind: vscode.CompletionItemKind.Variable,
@@ -59,14 +58,15 @@ function getVariableCompletionItems(variables: Variable[]): vscode.CompletionIte
 function getGhostCompletionItems(ghosts: Ghost[], triggerParameterHints: boolean): vscode.CompletionItem[] {
     return ghosts.map(ghost => {
         const parameters = ghost.parameterTypes.map(getSimpleName).join(", ");
-        const parametersStr = `(${parameters})`;
-        const ghostSig = `${ghost.returnType} ${ghost.name}${parametersStr}`;
+        const ghostSig = `${ghost.returnType} ${ghost.name}(${parameters})`;
+        const isState = /^state\d+\(_\) == \d+$/.test(ghost.refinement);
+        const description = isState ? "state" : "ghost";
         return createCompletionItem({
             name: ghost.name,
             kind: vscode.CompletionItemKind.Function,
-            labelDetail: parametersStr,
-            description: ghost.returnType,
-            detail: "ghost",
+            labelDetail: `(${parameters})`,
+            description,
+            detail: description,
             codeBlocks: [ghostSig],
             insertText: triggerParameterHints ? `${ghost.name}($1)` : ghost.name,
             triggerParameterHints,
@@ -81,15 +81,14 @@ function getAliasCompletionItems(aliases: Alias[], triggerParameterHints: boolea
                 const type = getSimpleName(alias.types[index]);
                 return `${type} ${parameter}`;
             }).join(", ");
-        const parametersStr = `(${parameters})`;
-        const aliasSig = `${alias.name}${parametersStr} { ${alias.predicate} }`;
-
+        const aliasSig = `${alias.name}(${parameters}) { ${alias.predicate} }`;
+        const description = "alias";
         return createCompletionItem({
             name: alias.name,
             kind: vscode.CompletionItemKind.Function,
-            labelDetail: parametersStr,
-            description: alias.predicate,
-            detail: "alias",
+            labelDetail: `(${parameters}){ ${alias.predicate} }`,
+            description,
+            detail: description,
             codeBlocks: [aliasSig],
             insertText: triggerParameterHints ? `${alias.name}($1)` : alias.name,
             triggerParameterHints,

--- a/client/src/services/autocomplete.ts
+++ b/client/src/services/autocomplete.ts
@@ -23,11 +23,12 @@ export function registerAutocomplete(context: vscode.ExtensionContext) {
 
 function getContextCompletionItems(context: ContextHistory, file: string, nextChar: string): vscode.CompletionItem[] {
     const variablesInScope = getVariablesInScope(file, extension.selection);
+    const inScope = variablesInScope !== null;
     const triggerParameterHints = nextChar !== "(";
-    const variableItems = getVariableCompletionItems([...variablesInScope, ...context.globalVars]); // not including instance vars
+    const variableItems = getVariableCompletionItems([...(variablesInScope || []), ...context.globalVars]); // not including instance vars
     const ghostItems = getGhostCompletionItems(context.ghosts, triggerParameterHints);
     const aliasItems = getAliasCompletionItems(context.aliases, triggerParameterHints);
-    const keywordItems = getKeywordsCompletionItems(triggerParameterHints);
+    const keywordItems = getKeywordsCompletionItems(triggerParameterHints, inScope);
     const allItems = [...variableItems, ...ghostItems, ...aliasItems, ...keywordItems];
     
     // remove duplicates
@@ -96,7 +97,7 @@ function getAliasCompletionItems(aliases: Alias[], triggerParameterHints: boolea
     });
 }
 
-function getKeywordsCompletionItems(triggerParameterHints: boolean): vscode.CompletionItem[] {
+function getKeywordsCompletionItems(triggerParameterHints: boolean, inScope: boolean): vscode.CompletionItem[] {
     const thisItem = createCompletionItem({
         name: "this",
         kind: vscode.CompletionItemKind.Keyword,
@@ -113,14 +114,18 @@ function getKeywordsCompletionItems(triggerParameterHints: boolean): vscode.Comp
         insertText: triggerParameterHints ? "old($1)" : "old",
         triggerParameterHints,
     });
-    const returnItem = createCompletionItem({
-        name: "return",
-        kind: vscode.CompletionItemKind.Keyword,
-        description: "",
-        detail: "keyword",
-        documentationBlocks: ["Keyword referring to the **method return value**"],
-    });
-    return [thisItem, oldItem, returnItem];
+    const items: vscode.CompletionItem[] = [thisItem, oldItem];
+    if (!inScope) {
+        const returnItem = createCompletionItem({
+            name: "return",
+            kind: vscode.CompletionItemKind.Keyword,
+            description: "",
+            detail: "keyword",
+            documentationBlocks: ["Keyword referring to the **method return value**"],
+        });
+        items.push(returnItem);
+    }
+    return items;
 }
 
 type CompletionItemOptions = {

--- a/client/src/services/autocomplete.ts
+++ b/client/src/services/autocomplete.ts
@@ -36,7 +36,7 @@ function getContextCompletionItems(context: ContextHistory, file: string, nextCh
     const uniqueItems = new Map<string, vscode.CompletionItem>();
     allItems.forEach(item => {
         const label = typeof item.label === "string" ? item.label : item.label.label;
-        if (!uniqueItems.has(label)) uniqueItems.set(label, item);
+        if (!uniqueItems.has(label) && !label.startsWith("this#")) uniqueItems.set(label, item);
     });
     return Array.from(uniqueItems.values());
 }

--- a/client/src/services/autocomplete.ts
+++ b/client/src/services/autocomplete.ts
@@ -1,0 +1,141 @@
+import * as vscode from "vscode";
+import { extension } from "../state";
+import type { Variable, ContextHistory, Ghost, Alias } from "../types/context";
+import { LIQUIDJAVA_ANNOTATIONS } from "../utils/constants";
+import { getSimpleName } from "../utils/utils";
+import { getVariablesInScope } from "./context";
+
+const LIQUIDJAVA_ANNOTATION_START = new RegExp(`@(liquidjava\\.specification\\.)?(${LIQUIDJAVA_ANNOTATIONS.join("|")})\\s*\\(`, "g");
+
+/**
+ * Registers a completion provider for LiquidJava annotations, providing context-aware suggestions based on the current context history
+ */
+export function registerAutocomplete(context: vscode.ExtensionContext) {
+    context.subscriptions.push(
+        vscode.languages.registerCompletionItemProvider("java", {
+            provideCompletionItems(document, position) {
+                if (!isInsideLiquidJavaAnnotationString(document, position) || !extension.contextHistory) return null;
+                const file = document.uri.toString().replace("file://", "");
+                return getContextCompletionItems(extension.contextHistory, file);
+            },
+        })
+    );
+}
+
+function getContextCompletionItems(context: ContextHistory, file: string): vscode.CompletionItem[] {
+    const variables: Variable[] = [];
+    const variablesInScope = getVariablesInScope(file, extension.selection);
+    variables.push(...variablesInScope);
+    variables.push(...context.instanceVars);
+    variables.push(...context.globalVars);
+
+    const variableItems = getVariableCompletionItems(variablesInScope);
+    const ghostItems = getGhostCompletionItems(context.ghosts);
+    const aliasItems = getAliasCompletionItems(context.aliases);
+    const allItems = [...variableItems, ...ghostItems, ...aliasItems];
+    
+    // remove duplicates
+    const uniqueItems = new Map<string, vscode.CompletionItem>();
+    allItems.forEach(item => {
+        const label = typeof item.label === "string" ? item.label : item.label.label;
+        if (!uniqueItems.has(label)) {
+            uniqueItems.set(label, item);
+        }
+    });
+    return Array.from(uniqueItems.values());
+}
+
+function getVariableCompletionItems(variables: Variable[]): vscode.CompletionItem[] {
+    return variables.map(variable => {
+        const varSig = `${variable.type} ${variable.name}`;
+        const documentationBlocks: string[] = [];
+        if (variable.mainRefinement !== "true") documentationBlocks.push(`@Refinement("${variable.mainRefinement}")`);
+        documentationBlocks.push(varSig);
+
+        return createCompletionItem({
+            name: variable.name,
+            kind: vscode.CompletionItemKind.Variable,
+            description: variable.type,
+            detail: "variable",
+            documentationBlocks,
+        });
+    });
+}
+
+function getGhostCompletionItems(ghosts: Ghost[]): vscode.CompletionItem[] {
+    return ghosts.map(ghost => {
+        const parameters = ghost.parameterTypes.map(getSimpleName).join(", ");
+        const parametersStr = `(${parameters})`;
+        const ghostSig = `${ghost.returnType} ${ghost.name}${parametersStr}`;
+        return createCompletionItem({
+            name: ghost.name,
+            kind: vscode.CompletionItemKind.Function,
+            labelDetail: parametersStr,
+            description: ghost.returnType,
+            detail: "ghost",
+            documentationBlocks: [ghostSig],
+            insertText: `${ghost.name}($1)`,
+            triggerParameterHints: true,
+        });
+    });
+}
+
+function getAliasCompletionItems(aliases: Alias[]): vscode.CompletionItem[] {
+    return aliases.map(alias => {
+        const parameters = alias.parameters
+            .map((parameter, index) => {
+                const type = getSimpleName(alias.types[index]);
+                return `${type} ${parameter}`;
+            }).join(", ");
+        const parametersStr = `(${parameters})`;
+        const aliasSig = `${alias.name}${parametersStr} { ${alias.predicate} }`;
+
+        return createCompletionItem({
+            name: alias.name,
+            kind: vscode.CompletionItemKind.Function,
+            labelDetail: parametersStr,
+            description: alias.predicate,
+            detail: "alias",
+            documentationBlocks: [aliasSig],
+            insertText: `${alias.name}($1)`,
+            triggerParameterHints: true,
+        });
+    });
+}
+
+type CompletionItemOptions = {
+    name: string;
+    kind: vscode.CompletionItemKind;
+    description?: string;
+    labelDetail?: string;
+    detail: string;
+    documentationBlocks: string[];
+    insertText?: string;
+    triggerParameterHints?: boolean;
+}
+
+function createCompletionItem({ name, kind, labelDetail, description, detail, documentationBlocks, insertText, triggerParameterHints }: CompletionItemOptions): vscode.CompletionItem {
+    const item = new vscode.CompletionItem(name, kind);
+    item.label = { label: name, detail: labelDetail, description };
+    item.detail = detail;
+    if (insertText) item.insertText = new vscode.SnippetString(insertText);
+    if (triggerParameterHints) item.command = { command: "editor.action.triggerParameterHints", title: "Trigger Parameter Hints" };
+
+    const documentation = new vscode.MarkdownString();
+    documentationBlocks.forEach(block => documentation.appendCodeblock(block));
+    item.documentation = documentation;
+    return item;
+}
+
+function isInsideLiquidJavaAnnotationString(document: vscode.TextDocument, position: vscode.Position): boolean {
+    const textUntilCursor = document.getText(new vscode.Range(new vscode.Position(0, 0), position));
+    LIQUIDJAVA_ANNOTATION_START.lastIndex = 0;
+    let match: RegExpExecArray | null = null;
+    let lastAnnotationStart = -1;
+    while ((match = LIQUIDJAVA_ANNOTATION_START.exec(textUntilCursor)) !== null) {
+        lastAnnotationStart = match.index;
+    }
+    if (lastAnnotationStart === -1) return false;
+    const fromLastAnnotation = textUntilCursor.slice(lastAnnotationStart);
+    return !fromLastAnnotation.includes(")");
+}

--- a/client/src/services/autocomplete.ts
+++ b/client/src/services/autocomplete.ts
@@ -118,6 +118,7 @@ function getKeywordsCompletionItems(): vscode.CompletionItem[] {
         description: "",
         detail: "keyword",
         documentationBlocks: ["Keyword referring to the **previous state of the current instance**"],
+        insertText: "old($1)",
         triggerParameterHints: true,
     });
     const resultItem = createCompletionItem({

--- a/client/src/services/autocomplete.ts
+++ b/client/src/services/autocomplete.ts
@@ -1,11 +1,9 @@
 import * as vscode from "vscode";
 import { extension } from "../state";
 import type { Variable, ContextHistory, Ghost, Alias } from "../types/context";
-import { LIQUIDJAVA_ANNOTATIONS } from "../utils/constants";
 import { getSimpleName } from "../utils/utils";
 import { getVariablesInScope } from "./context";
-
-const LIQUIDJAVA_ANNOTATION_START = new RegExp(`@(liquidjava\\.specification\\.)?(${LIQUIDJAVA_ANNOTATIONS.join("|")})\\s*\\(`, "g");
+import { LIQUIDJAVA_ANNOTATION_START } from "../utils/constants";
 
 /**
  * Registers a completion provider for LiquidJava annotations, providing context-aware suggestions based on the current context history
@@ -162,14 +160,13 @@ function isInsideLiquidJavaAnnotationString(document: vscode.TextDocument, posit
         lastAnnotationStart = match.index;
     }
     if (lastAnnotationStart === -1) return false;
+    
     const fromLastAnnotation = textUntilCursor.slice(lastAnnotationStart);
-
     let parenthesisDepth = 0;
     let isInsideString = false;
     for (let i = 0; i < fromLastAnnotation.length; i++) {
         const char = fromLastAnnotation[i];
         const previousChar = i > 0 ? fromLastAnnotation[i - 1] : "";
-
         if (char === '"' && previousChar !== "\\") {
             isInsideString = !isInsideString;
             continue;

--- a/client/src/services/autocomplete.ts
+++ b/client/src/services/autocomplete.ts
@@ -32,7 +32,8 @@ function getContextCompletionItems(context: ContextHistory, file: string): vscod
     const variableItems = getVariableCompletionItems(variablesInScope);
     const ghostItems = getGhostCompletionItems(context.ghosts);
     const aliasItems = getAliasCompletionItems(context.aliases);
-    const allItems = [...variableItems, ...ghostItems, ...aliasItems];
+    const keywordItems = getKeywordsCompletionItems();
+    const allItems = [...variableItems, ...ghostItems, ...aliasItems, ...keywordItems];
     
     // remove duplicates
     const uniqueItems = new Map<string, vscode.CompletionItem>();
@@ -48,16 +49,16 @@ function getContextCompletionItems(context: ContextHistory, file: string): vscod
 function getVariableCompletionItems(variables: Variable[]): vscode.CompletionItem[] {
     return variables.map(variable => {
         const varSig = `${variable.type} ${variable.name}`;
-        const documentationBlocks: string[] = [];
-        if (variable.mainRefinement !== "true") documentationBlocks.push(`@Refinement("${variable.mainRefinement}")`);
-        documentationBlocks.push(varSig);
+        const codeBlocks: string[] = [];
+        if (variable.mainRefinement !== "true") codeBlocks.push(`@Refinement("${variable.mainRefinement}")`);
+        codeBlocks.push(varSig);
 
         return createCompletionItem({
             name: variable.name,
             kind: vscode.CompletionItemKind.Variable,
             description: variable.type,
             detail: "variable",
-            documentationBlocks,
+            codeBlocks,
         });
     });
 }
@@ -73,7 +74,7 @@ function getGhostCompletionItems(ghosts: Ghost[]): vscode.CompletionItem[] {
             labelDetail: parametersStr,
             description: ghost.returnType,
             detail: "ghost",
-            documentationBlocks: [ghostSig],
+            codeBlocks: [ghostSig],
             insertText: `${ghost.name}($1)`,
             triggerParameterHints: true,
         });
@@ -96,11 +97,37 @@ function getAliasCompletionItems(aliases: Alias[]): vscode.CompletionItem[] {
             labelDetail: parametersStr,
             description: alias.predicate,
             detail: "alias",
-            documentationBlocks: [aliasSig],
+            codeBlocks: [aliasSig],
             insertText: `${alias.name}($1)`,
             triggerParameterHints: true,
         });
     });
+}
+
+function getKeywordsCompletionItems(): vscode.CompletionItem[] {
+    const thisItem = createCompletionItem({
+        name: "this",
+        kind: vscode.CompletionItemKind.Keyword,
+        description: "",
+        detail: "keyword",
+        documentationBlocks: ["Keyword referring to the **current instance**"],
+    });
+    const oldItem = createCompletionItem({
+        name: "old",
+        kind: vscode.CompletionItemKind.Keyword,
+        description: "",
+        detail: "keyword",
+        documentationBlocks: ["Keyword referring to the **previous state of the current instance**"],
+        triggerParameterHints: true,
+    });
+    const resultItem = createCompletionItem({
+        name: "return",
+        kind: vscode.CompletionItemKind.Keyword,
+        description: "",
+        detail: "keyword",
+        documentationBlocks: ["Keyword referring to the **method return value**"],
+    });
+    return [thisItem, oldItem, resultItem];
 }
 
 type CompletionItemOptions = {
@@ -109,12 +136,13 @@ type CompletionItemOptions = {
     description?: string;
     labelDetail?: string;
     detail: string;
-    documentationBlocks: string[];
+    documentationBlocks?: string[];
+    codeBlocks?: string[];
     insertText?: string;
     triggerParameterHints?: boolean;
 }
 
-function createCompletionItem({ name, kind, labelDetail, description, detail, documentationBlocks, insertText, triggerParameterHints }: CompletionItemOptions): vscode.CompletionItem {
+function createCompletionItem({ name, kind, labelDetail, description, detail, documentationBlocks, codeBlocks, insertText, triggerParameterHints }: CompletionItemOptions): vscode.CompletionItem {
     const item = new vscode.CompletionItem(name, kind);
     item.label = { label: name, detail: labelDetail, description };
     item.detail = detail;
@@ -122,8 +150,10 @@ function createCompletionItem({ name, kind, labelDetail, description, detail, do
     if (triggerParameterHints) item.command = { command: "editor.action.triggerParameterHints", title: "Trigger Parameter Hints" };
 
     const documentation = new vscode.MarkdownString();
-    documentationBlocks.forEach(block => documentation.appendCodeblock(block));
+    if (documentationBlocks) documentationBlocks.forEach(block => documentation.appendMarkdown(block));
+    if (codeBlocks) codeBlocks.forEach(block => documentation.appendCodeblock(block));  
     item.documentation = documentation;
+    
     return item;
 }
 
@@ -137,5 +167,20 @@ function isInsideLiquidJavaAnnotationString(document: vscode.TextDocument, posit
     }
     if (lastAnnotationStart === -1) return false;
     const fromLastAnnotation = textUntilCursor.slice(lastAnnotationStart);
-    return !fromLastAnnotation.includes(")");
+
+    let parenthesisDepth = 0;
+    let isInsideString = false;
+    for (let i = 0; i < fromLastAnnotation.length; i++) {
+        const char = fromLastAnnotation[i];
+        const previousChar = i > 0 ? fromLastAnnotation[i - 1] : "";
+
+        if (char === '"' && previousChar !== "\\") {
+            isInsideString = !isInsideString;
+            continue;
+        }
+        if (isInsideString) continue;
+        if (char === "(") parenthesisDepth++;
+        if (char === ")") parenthesisDepth--;
+    }
+    return parenthesisDepth > 0;
 }

--- a/client/src/services/autocomplete.ts
+++ b/client/src/services/autocomplete.ts
@@ -16,32 +16,27 @@ export function registerAutocomplete(context: vscode.ExtensionContext) {
             provideCompletionItems(document, position) {
                 if (!isInsideLiquidJavaAnnotationString(document, position) || !extension.contextHistory) return null;
                 const file = document.uri.toString().replace("file://", "");
-                return getContextCompletionItems(extension.contextHistory, file);
+                const nextChar = document.getText(new vscode.Range(position, position.translate(0, 1)));
+                return getContextCompletionItems(extension.contextHistory, file, nextChar);
             },
         })
     );
 }
 
-function getContextCompletionItems(context: ContextHistory, file: string): vscode.CompletionItem[] {
-    const variables: Variable[] = [];
+function getContextCompletionItems(context: ContextHistory, file: string, nextChar: string): vscode.CompletionItem[] {
     const variablesInScope = getVariablesInScope(file, extension.selection);
-    variables.push(...variablesInScope);
-    variables.push(...context.instanceVars);
-    variables.push(...context.globalVars);
-
-    const variableItems = getVariableCompletionItems(variablesInScope);
-    const ghostItems = getGhostCompletionItems(context.ghosts);
-    const aliasItems = getAliasCompletionItems(context.aliases);
-    const keywordItems = getKeywordsCompletionItems();
+    const triggerParameterHints = nextChar !== "(";
+    const variableItems = getVariableCompletionItems([...variablesInScope, ...context.instanceVars, ...context.globalVars]);
+    const ghostItems = getGhostCompletionItems(context.ghosts, triggerParameterHints);
+    const aliasItems = getAliasCompletionItems(context.aliases, triggerParameterHints);
+    const keywordItems = getKeywordsCompletionItems(triggerParameterHints);
     const allItems = [...variableItems, ...ghostItems, ...aliasItems, ...keywordItems];
     
     // remove duplicates
     const uniqueItems = new Map<string, vscode.CompletionItem>();
     allItems.forEach(item => {
         const label = typeof item.label === "string" ? item.label : item.label.label;
-        if (!uniqueItems.has(label)) {
-            uniqueItems.set(label, item);
-        }
+        if (!uniqueItems.has(label)) uniqueItems.set(label, item);
     });
     return Array.from(uniqueItems.values());
 }
@@ -63,7 +58,7 @@ function getVariableCompletionItems(variables: Variable[]): vscode.CompletionIte
     });
 }
 
-function getGhostCompletionItems(ghosts: Ghost[]): vscode.CompletionItem[] {
+function getGhostCompletionItems(ghosts: Ghost[], triggerParameterHints: boolean): vscode.CompletionItem[] {
     return ghosts.map(ghost => {
         const parameters = ghost.parameterTypes.map(getSimpleName).join(", ");
         const parametersStr = `(${parameters})`;
@@ -75,13 +70,13 @@ function getGhostCompletionItems(ghosts: Ghost[]): vscode.CompletionItem[] {
             description: ghost.returnType,
             detail: "ghost",
             codeBlocks: [ghostSig],
-            insertText: `${ghost.name}($1)`,
-            triggerParameterHints: true,
+            insertText: triggerParameterHints ? `${ghost.name}($1)` : ghost.name,
+            triggerParameterHints,
         });
     });
 }
 
-function getAliasCompletionItems(aliases: Alias[]): vscode.CompletionItem[] {
+function getAliasCompletionItems(aliases: Alias[], triggerParameterHints: boolean): vscode.CompletionItem[] {
     return aliases.map(alias => {
         const parameters = alias.parameters
             .map((parameter, index) => {
@@ -98,13 +93,13 @@ function getAliasCompletionItems(aliases: Alias[]): vscode.CompletionItem[] {
             description: alias.predicate,
             detail: "alias",
             codeBlocks: [aliasSig],
-            insertText: `${alias.name}($1)`,
-            triggerParameterHints: true,
+            insertText: triggerParameterHints ? `${alias.name}($1)` : alias.name,
+            triggerParameterHints,
         });
     });
 }
 
-function getKeywordsCompletionItems(): vscode.CompletionItem[] {
+function getKeywordsCompletionItems(triggerParameterHints: boolean): vscode.CompletionItem[] {
     const thisItem = createCompletionItem({
         name: "this",
         kind: vscode.CompletionItemKind.Keyword,
@@ -118,8 +113,8 @@ function getKeywordsCompletionItems(): vscode.CompletionItem[] {
         description: "",
         detail: "keyword",
         documentationBlocks: ["Keyword referring to the **previous state of the current instance**"],
-        insertText: "old($1)",
-        triggerParameterHints: true,
+        insertText: triggerParameterHints ? "old($1)" : "old",
+        triggerParameterHints,
     });
     const resultItem = createCompletionItem({
         name: "return",

--- a/client/src/services/autocomplete.ts
+++ b/client/src/services/autocomplete.ts
@@ -114,14 +114,14 @@ function getKeywordsCompletionItems(triggerParameterHints: boolean): vscode.Comp
         insertText: triggerParameterHints ? "old($1)" : "old",
         triggerParameterHints,
     });
-    const resultItem = createCompletionItem({
+    const returnItem = createCompletionItem({
         name: "return",
         kind: vscode.CompletionItemKind.Keyword,
         description: "",
         detail: "keyword",
         documentationBlocks: ["Keyword referring to the **method return value**"],
     });
-    return [thisItem, oldItem, resultItem];
+    return [thisItem, oldItem, returnItem];
 }
 
 type CompletionItemOptions = {
@@ -160,7 +160,7 @@ function isInsideLiquidJavaAnnotationString(document: vscode.TextDocument, posit
         lastAnnotationStart = match.index;
     }
     if (lastAnnotationStart === -1) return false;
-    
+
     const fromLastAnnotation = textUntilCursor.slice(lastAnnotationStart);
     let parenthesisDepth = 0;
     let isInsideString = false;

--- a/client/src/services/context.ts
+++ b/client/src/services/context.ts
@@ -30,7 +30,8 @@ export function getVariablesInScope(file: string, selection: Selection): Variabl
     const variablesInScope = mostSpecificScope ? fileVars[mostSpecificScope] : [];
 
     // filter variables to only include those that are reachable based on their position
-    return getReachableVariables(variablesInScope, selection);
+    const reachableVariables = getReachableVariables(variablesInScope, selection);
+    return reachableVariables.filter(v => !v.name.startsWith("this#"))
 }
 
 function parseScopeString(scope: string): Selection {

--- a/client/src/services/context.ts
+++ b/client/src/services/context.ts
@@ -5,12 +5,14 @@ export function handleContextHistory(contextHistory: ContextHistory) {
     extension.contextHistory = contextHistory;
 }
 
-export function getVariablesInScope(file: string, selection: Selection): Variable[] {
-    if (!extension.contextHistory || !selection || !file) return [];
+// Gets the variables in scope for a given file and position
+// Returns null if position not in any scope
+export function getVariablesInScope(file: string, selection: Selection): Variable[] | null {
+    if (!extension.contextHistory || !selection || !file) return null;
 
     // get variables in file
     const fileVars = extension.contextHistory.vars[file];
-    if (!fileVars) return [];
+    if (!fileVars) return null;
 
     // get variables in the current scope based on the selection
     let mostSpecificScope: string | null = null;
@@ -27,11 +29,13 @@ export function getVariablesInScope(file: string, selection: Selection): Variabl
             }
         }
     }
-    const variablesInScope = mostSpecificScope ? fileVars[mostSpecificScope] : [];
+    if (mostSpecificScope === null)
+        return null;
 
     // filter variables to only include those that are reachable based on their position
+    const variablesInScope = fileVars[mostSpecificScope];
     const reachableVariables = getReachableVariables(variablesInScope, selection);
-    return reachableVariables.filter(v => !v.name.startsWith("this#"))
+    return reachableVariables.filter(v => !v.name.startsWith("this#"));
 }
 
 function parseScopeString(scope: string): Selection {

--- a/client/src/services/context.ts
+++ b/client/src/services/context.ts
@@ -1,0 +1,57 @@
+import { extension } from "../state";
+import { ContextHistory, Selection, Variable } from "../types/context";
+
+export function handleContextHistory(contextHistory: ContextHistory) {
+    extension.contextHistory = contextHistory;
+}
+
+export function getVariablesInScope(file: string, selection: Selection): Variable[] {
+    if (!extension.contextHistory || !selection || !file) return [];
+
+    // get variables in file
+    const fileVars = extension.contextHistory.vars[file];
+    if (!fileVars) return [];
+
+    // get variables in the current scope based on the selection
+    let mostSpecificScope: string | null = null;
+    let minScopeSize = Infinity;
+
+    // find the most specific scope that contains the selection
+    for (const scope of Object.keys(fileVars)) {
+        const scopeSelection = parseScopeString(scope);
+        if (isSelectionWithinScope(selection, scopeSelection)) {
+            const scopeSize = (scopeSelection.endLine - scopeSelection.startLine) * 10000 + (scopeSelection.endColumn - scopeSelection.startColumn);
+            if (scopeSize < minScopeSize) {
+                mostSpecificScope = scope;
+                minScopeSize = scopeSize;
+            }
+        }
+    }
+    const variablesInScope = mostSpecificScope ? fileVars[mostSpecificScope] : [];
+
+    // filter variables to only include those that are reachable based on their position
+    return getReachableVariables(variablesInScope, selection);
+}
+
+function parseScopeString(scope: string): Selection {
+    const [start, end] = scope.split("-");
+    const [startLine, startColumn] = start.split(":").map(Number);
+    const [endLine, endColumn] = end.split(":").map(Number);
+    return { startLine, startColumn, endLine, endColumn };
+}
+
+function isSelectionWithinScope(selection: Selection, scope: Selection): boolean {
+    const startsWithin = selection.startLine > scope.startLine || 
+        (selection.startLine === scope.startLine && selection.startColumn >= scope.startColumn);
+    const endsWithin = selection.endLine < scope.endLine || 
+        (selection.endLine === scope.endLine && selection.endColumn <= scope.endColumn);
+    return startsWithin && endsWithin;
+}
+
+function getReachableVariables(variables: Variable[], selection: Selection): Variable[] {
+    return variables.filter((variable) => {
+        const placement = variable.placementInCode?.position;
+        if (!placement) return true;
+        return placement.line < selection.startLine || (placement.line === selection.startLine && placement.column <= selection.startColumn);
+    });
+}

--- a/client/src/services/events.ts
+++ b/client/src/services/events.ts
@@ -1,6 +1,11 @@
 import * as vscode from 'vscode';
 import { extension } from '../state';
 import { updateStateMachine } from './state-machine';
+import { Selection } from '../types/context';
+
+let selectionTimeout: NodeJS.Timeout | null = null;
+let currentSelection: Selection = { startLine: 0, startColumn: 0, endLine: 0, endColumn: 0 };
+const SELECTION_DEBOUNCE_TIME = 250; // ms
 
 /**
  * Initializes file system event listeners
@@ -12,11 +17,15 @@ export function registerEvents(context: vscode.ExtensionContext) {
         vscode.window.onDidChangeActiveTextEditor(async editor => {
             if (!editor || editor.document.languageId !== "java") return;
             await onActiveFileChange(editor);
-            
         }),
         vscode.workspace.onDidSaveTextDocument(async document => {
             if (document.uri.scheme !== 'file' || document.languageId !== "java") return;
             await updateStateMachine(document)
+        }),
+        vscode.window.onDidChangeTextEditorSelection(event => {
+            if (event.textEditor.document.uri.scheme !== 'file' || event.textEditor.document.languageId !== "java") return;
+            if (event.selections.length === 0) return;
+            onSelectionChange(event);
         })
     );
 }
@@ -29,4 +38,25 @@ export async function onActiveFileChange(editor: vscode.TextEditor) {
     extension.file = editor.document.uri.fsPath;
     extension.webview?.sendMessage({ type: "file", file: extension.file });
     await updateStateMachine(editor.document);
+}
+
+/**
+ * Handles selection change events
+ * @param event The selection change event
+ */
+export async function onSelectionChange(event: vscode.TextEditorSelectionChangeEvent) {        
+    // update current selection
+    const selectionStart = event.selections[0].start;
+    const selectionEnd = event.selections[0].end;
+    currentSelection = {
+        startLine: selectionStart.line,
+        startColumn: selectionStart.character,
+        endLine: selectionEnd.line,
+        endColumn: selectionEnd.character
+    };
+    // debounce selection changes
+    if (selectionTimeout) clearTimeout(selectionTimeout);
+    selectionTimeout = setTimeout(() => {
+        extension.selection = currentSelection;
+    }, SELECTION_DEBOUNCE_TIME);
 }

--- a/client/src/services/events.ts
+++ b/client/src/services/events.ts
@@ -2,10 +2,10 @@ import * as vscode from 'vscode';
 import { extension } from '../state';
 import { updateStateMachine } from './state-machine';
 import { Selection } from '../types/context';
+import { SELECTION_DEBOUNCE_MS } from '../utils/constants';
 
 let selectionTimeout: NodeJS.Timeout | null = null;
 let currentSelection: Selection = { startLine: 0, startColumn: 0, endLine: 0, endColumn: 0 };
-const SELECTION_DEBOUNCE_TIME = 250; // ms
 
 /**
  * Initializes file system event listeners
@@ -56,7 +56,5 @@ export async function onSelectionChange(event: vscode.TextEditorSelectionChangeE
     };
     // debounce selection changes
     if (selectionTimeout) clearTimeout(selectionTimeout);
-    selectionTimeout = setTimeout(() => {
-        extension.selection = currentSelection;
-    }, SELECTION_DEBOUNCE_TIME);
+    selectionTimeout = setTimeout(() => extension.selection = currentSelection, SELECTION_DEBOUNCE_MS);
 }

--- a/client/src/state.ts
+++ b/client/src/state.ts
@@ -6,6 +6,7 @@ import { LiquidJavaLogger } from "./services/logger";
 import { LiquidJavaWebviewProvider } from "./webview/provider";
 import type { LJDiagnostic } from "./types/diagnostics";
 import type { StateMachine } from "./types/fsm";
+import { ContextHistory, Selection } from "./types/context";
 
 export class ExtensionState {
     // server/client state
@@ -22,6 +23,8 @@ export class ExtensionState {
     file?: string;
     diagnostics?: LJDiagnostic[];
     stateMachine?: StateMachine;
+    contextHistory?: ContextHistory;
+    selection?: Selection;
 }
 
 export const extension = new ExtensionState();

--- a/client/src/types/context.ts
+++ b/client/src/types/context.ts
@@ -1,0 +1,41 @@
+import { PlacementInCode } from "./diagnostics";
+
+// Type definitions used for LiquidJava context information
+
+export type Variable = {
+  name: string;
+  type: string;
+  refinement: string;
+  mainRefinement: string;
+  placementInCode: PlacementInCode | null;
+}
+
+export type Ghost = {
+  name: string;
+  qualifiedName: string;
+  returnType: string;
+  parameterTypes: string[];
+  refinement: string;
+}
+
+export type Alias = {
+  name: string;
+  parameters: string[];
+  types: string[];
+  predicate: string;
+}
+
+export type ContextHistory = {
+  vars: Record<string, Record<string, Variable[]>>; // file -> (scope -> variables in scope)
+  instanceVars: Variable[];
+  globalVars: Variable[];
+  ghosts: Ghost[];
+  aliases: Alias[];
+}
+
+export type Selection = {
+  startLine: number;
+  startColumn: number;
+  endLine: number;
+  endColumn: number;
+}

--- a/client/src/utils/constants.ts
+++ b/client/src/utils/constants.ts
@@ -2,6 +2,7 @@ export const SERVER_JAR = "language-server-liquidjava.jar";
 export const JAVA_BINARY = "java";
 export const DEBUG_MODE = false;
 export const DEBUG_PORT = 50000;
+export const SELECTION_DEBOUNCE_MS = 250;
 export const LIQUIDJAVA_SCOPES = [
     "source.liquidjava keyword.other.liquidjava",
     "source.liquidjava entity.name.function.liquidjava",
@@ -26,3 +27,4 @@ export const LIQUIDJAVA_ANNOTATIONS = [
     "StateRefinement",
     "ExternalRefinementsFor",
 ]
+export const LIQUIDJAVA_ANNOTATION_START = new RegExp(`@(liquidjava\\.specification\\.)?(${LIQUIDJAVA_ANNOTATIONS.join("|")})\\s*\\(`, "g");

--- a/client/src/utils/constants.ts
+++ b/client/src/utils/constants.ts
@@ -17,3 +17,12 @@ export const LIQUIDJAVA_SCOPES = [
     "constant.language.boolean.liquidjava",
     "constant.numeric.liquidjava",
 ];
+export const LIQUIDJAVA_ANNOTATIONS = [
+    "Refinement",
+    "RefinementAlias",
+    "RefinementPredicate",
+    "StateSet",
+    "Ghost",
+    "StateRefinement",
+    "ExternalRefinementsFor",
+]

--- a/client/src/utils/utils.ts
+++ b/client/src/utils/utils.ts
@@ -123,3 +123,8 @@ export async function killProcess(proc?: child_process.ChildProcess) {
         }
     });
 }
+
+export function getSimpleName(qualifiedName: string): string {
+    const parts = qualifiedName.split(".");
+    return parts[parts.length - 1];
+}

--- a/client/syntaxes/liquidjava.json
+++ b/client/syntaxes/liquidjava.json
@@ -91,6 +91,7 @@
   "repository": {
     "keywords": {
       "patterns": [
+        { "match": "\\bthis\\b", "name": "variable.language.this.liquidjava" },
         { "match": "\\bghost\\b|\\balias\\b|\\btype\\b", "name": "keyword.other.liquidjava" }
       ]
     },

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -172,14 +172,14 @@
 		<!-- <dependency>
 			<groupId>liquidjava</groupId>
 			<artifactId>verifier</artifactId>
-			<version>0.0.1</version>
+			<version>0.0.13</version>
 			<scope>system</scope>
 			<systemPath>${project.basedir}/libs/liquidjava-verifier.jar</systemPath>
 		</dependency> -->
 		<dependency>
 			<groupId>io.github.liquid-java</groupId>
 			<artifactId>liquidjava-verifier</artifactId>
-			<version>0.0.12</version>
+			<version>0.0.13</version>
 		</dependency>
 		<dependency>
 			<groupId>tools.aqua</groupId>

--- a/server/src/main/java/LJDiagnosticsHandler.java
+++ b/server/src/main/java/LJDiagnosticsHandler.java
@@ -46,7 +46,6 @@ public class LJDiagnosticsHandler {
             }
             return new LJDiagnostics(errors, warnings);
         } catch (Exception e) {
-            System.err.println("LiquidJava verifier exception: " + e.getMessage());
             e.printStackTrace();
             errors.add(new CustomError("LiquidJava verification failed, check for Java errors"));
             return new LJDiagnostics(errors, warnings);

--- a/server/src/main/java/LJDiagnosticsService.java
+++ b/server/src/main/java/LJDiagnosticsService.java
@@ -15,6 +15,8 @@ import org.eclipse.lsp4j.services.TextDocumentService;
 import org.eclipse.lsp4j.services.WorkspaceService;
 
 import liquidjava.diagnostics.LJDiagnostic;
+import liquidjava.processor.context.ContextHistory;
+import utils.ContextHistoryConverter;
 import utils.DiagnosticConverter;
 import utils.PathUtils;
 
@@ -58,6 +60,7 @@ public class LJDiagnosticsService implements TextDocumentService, WorkspaceServi
         });
         List<LJDiagnostic> diagnostics = Stream.concat(ljDiagnostics.errors().stream(), ljDiagnostics.warnings().stream()).collect(Collectors.toList());
         sendDiagnosticsNotification(diagnostics);
+        this.client.sendContext(ContextHistoryConverter.convertToDTO(ContextHistory.getInstance()));
     }
 
     /**

--- a/server/src/main/java/LJLanguageClient.java
+++ b/server/src/main/java/LJLanguageClient.java
@@ -1,6 +1,9 @@
 import java.util.List;
 
 import org.eclipse.lsp4j.services.LanguageClient;
+
+import dtos.context.ContextHistoryDTO;
+
 import org.eclipse.lsp4j.jsonrpc.services.JsonNotification;
 
 /**
@@ -10,8 +13,15 @@ public interface LJLanguageClient extends LanguageClient {
     
     /**
      * Sends custom diagnostics notification to the client
-     * @param diagnostics the LiquidJava diagnostics DTOs to send (can be any DTO type)
+     * @param diagnostics the LiquidJava diagnostics to send
      */
     @JsonNotification("liquidjava/diagnostics")
     void sendDiagnostics(List<Object> diagnostics);
+
+    /**
+     * Sends the context history to the client
+     * @param contextHistory the context history to send
+     */
+    @JsonNotification("liquidjava/context")
+    void sendContext(ContextHistoryDTO contextHistory);
 }

--- a/server/src/main/java/dtos/context/AliasDTO.java
+++ b/server/src/main/java/dtos/context/AliasDTO.java
@@ -1,0 +1,25 @@
+package dtos.context;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import liquidjava.processor.context.AliasWrapper;
+
+/**
+ * DTO for serializing AliasWrapper instances to JSON.
+ */
+public record AliasDTO(
+    String name,
+    List<String> parameters,
+    List<String> types,
+    String predicate
+) {
+    public static AliasDTO from(AliasWrapper aliasWrapper) {
+        return new AliasDTO(
+            aliasWrapper.getName(),
+            aliasWrapper.getVarNames(),
+            aliasWrapper.getTypes().stream().map(ContextHistoryDTO::stringifyType).collect(Collectors.toList()),
+            aliasWrapper.getClonedPredicate().toString()
+        );
+    }
+}

--- a/server/src/main/java/dtos/context/ContextHistoryDTO.java
+++ b/server/src/main/java/dtos/context/ContextHistoryDTO.java
@@ -1,0 +1,24 @@
+package dtos.context;
+
+import java.util.List;
+import java.util.Map;
+
+import spoon.reflect.reference.CtTypeReference;
+
+/**
+ * DTO for serializing ContextHistory instances to JSON.
+ */
+public record ContextHistoryDTO(
+    Map<String, Map<String, List<VariableDTO>>> vars,
+    List<VariableDTO> instanceVars,
+    List<VariableDTO> globalVars,
+    List<GhostDTO> ghosts,
+    List<AliasDTO> aliases
+) {
+    public static String stringifyType(CtTypeReference<?> typeReference) {
+        if (typeReference == null)
+            return "";
+        String qualifiedName = typeReference.getQualifiedName();
+        return qualifiedName == null || qualifiedName.isBlank() ? typeReference.toString() : qualifiedName;
+    }
+}

--- a/server/src/main/java/dtos/context/GhostDTO.java
+++ b/server/src/main/java/dtos/context/GhostDTO.java
@@ -1,0 +1,27 @@
+package dtos.context;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import liquidjava.processor.context.GhostState;
+
+/**
+ * DTO for serializing GhostState instances to JSON.
+ */
+public record GhostDTO(
+    String name,
+    String qualifiedName,
+    String returnType,
+    List<String> parameterTypes,
+    String refinement
+) {
+    public static GhostDTO from(GhostState ghostState) {
+        return new GhostDTO(
+            ghostState.getName(),
+            ghostState.getQualifiedName(),
+            ContextHistoryDTO.stringifyType(ghostState.getReturnType()),
+            ghostState.getParametersTypes().stream().map(ContextHistoryDTO::stringifyType).collect(Collectors.toList()),
+            ghostState.getRefinement() != null ? ghostState.getRefinement().toString() : null
+        );
+    }
+}

--- a/server/src/main/java/dtos/context/VariableDTO.java
+++ b/server/src/main/java/dtos/context/VariableDTO.java
@@ -1,0 +1,26 @@
+package dtos.context;
+
+import dtos.diagnostics.PlacementInCodeDTO;
+import liquidjava.processor.context.RefinedVariable;
+import spoon.reflect.reference.CtTypeReference;
+
+/**
+ * DTO for serializing RefinedVariable instances to JSON.
+ */
+public record VariableDTO(
+    String name,
+    String type,
+    String refinement,
+    String mainRefinement,
+    PlacementInCodeDTO placementInCode
+) {
+    public static VariableDTO from(RefinedVariable refinedVariable) {
+        return new VariableDTO(
+            refinedVariable.getName(),
+            ContextHistoryDTO.stringifyType(refinedVariable.getType()),
+            refinedVariable.getRefinement().toString(),
+            refinedVariable.getMainRefinement().toString(),
+            PlacementInCodeDTO.from(refinedVariable.getPlacementInCode())
+        );
+    }
+}

--- a/server/src/main/java/dtos/diagnostics/PlacementInCodeDTO.java
+++ b/server/src/main/java/dtos/diagnostics/PlacementInCodeDTO.java
@@ -8,9 +8,8 @@ import liquidjava.processor.context.PlacementInCode;
 public record PlacementInCodeDTO(String text, PositionDTO position) {
 
     public static PlacementInCodeDTO from(PlacementInCode placement) {
-        return new PlacementInCodeDTO(
-            placement.getText(),
-            PositionDTO.from(placement.getPosition())
-        );
+        if (placement == null)
+            return null;
+        return new PlacementInCodeDTO(placement.getText(), PositionDTO.from(placement.getPosition()));
     }
 }

--- a/server/src/main/java/utils/ContextHistoryConverter.java
+++ b/server/src/main/java/utils/ContextHistoryConverter.java
@@ -1,0 +1,49 @@
+package utils;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import dtos.context.AliasDTO;
+import dtos.context.ContextHistoryDTO;
+import dtos.context.GhostDTO;
+import dtos.context.VariableDTO;
+import liquidjava.processor.context.ContextHistory;
+import liquidjava.processor.context.RefinedVariable;
+
+/**
+ * Utility class for converting LiquidJava context objects to DTOs.
+ */
+public class ContextHistoryConverter {
+
+    /**
+     * Converts a ContextHistory to its DTO type.
+     * @param contextHistory the context history to convert
+     * @return the corresponding DTO
+     */
+    public static ContextHistoryDTO convertToDTO(ContextHistory contextHistory) {
+        return new ContextHistoryDTO(
+            toVariablesMap(contextHistory.getVars()),
+            contextHistory.getInstanceVars().stream().map(VariableDTO::from).collect(Collectors.toList()),
+            contextHistory.getGlobalVars().stream().map(VariableDTO::from).collect(Collectors.toList()),
+            contextHistory.getGhosts().stream().map(GhostDTO::from).collect(Collectors.toList()),
+            contextHistory.getAliases().stream().map(AliasDTO::from).collect(Collectors.toList())
+        );
+    }
+
+    private static Map<String, Map<String, List<VariableDTO>>> toVariablesMap(Map<String, Map<String, Set<RefinedVariable>>> vars) {
+        return vars.entrySet().stream().collect(Collectors.toMap(
+            Map.Entry::getKey,
+            entry -> entry.getValue().entrySet().stream().collect(Collectors.toMap(
+                Map.Entry::getKey,
+                innerEntry -> innerEntry.getValue().stream().map(VariableDTO::from).collect(Collectors.toList()),
+                (left, right) -> left,
+                HashMap::new
+            )),
+            (left, right) -> left,
+            HashMap::new
+        ));
+    }
+}

--- a/server/src/main/java/utils/ContextHistoryConverter.java
+++ b/server/src/main/java/utils/ContextHistoryConverter.java
@@ -25,7 +25,7 @@ public class ContextHistoryConverter {
      */
     public static ContextHistoryDTO convertToDTO(ContextHistory contextHistory) {
         return new ContextHistoryDTO(
-            toVariablesMap(contextHistory.getVars()),
+            toVariablesMap(contextHistory.getFileScopeVars()),
             contextHistory.getInstanceVars().stream().map(VariableDTO::from).collect(Collectors.toList()),
             contextHistory.getGlobalVars().stream().map(VariableDTO::from).collect(Collectors.toList()),
             contextHistory.getGhosts().stream().map(GhostDTO::from).collect(Collectors.toList()),


### PR DESCRIPTION
This PR adds autocomplete for refinements using the [context history from the verifier](https://github.com/liquid-java/liquidjava/pull/155).
It suggests **variables in scope**, **fields**, **ghosts**, **states**, **aliases**, and **keywords** (`this`, `old`, `return`), only when inside a string within a LiquidJava annotation (except for the parameter `msg`).
To only show the variables in scope, we update the current position of the cursor when it moves and then filter variables that aren't either in scope of the current position or their declaration is after the current position.

### Demo

https://github.com/user-attachments/assets/5468305c-186a-4215-ac35-3c317fbae78c
