### PR TITLE
Build Server JAR Automatically

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,10 +13,23 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: 17
+          distribution: temurin
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 20
+
+      - name: Build Server JAR
+        run: |
+          cd server
+          mvn clean package -DskipTests
+          mkdir -p ../client/server
+          cp target/language-server-liquidjava.jar ../client/server/
 
       - name: Install dependencies and build
         working-directory: ./client

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,8 +25,8 @@ jobs:
           node-version: 20
 
       - name: Build Server JAR
+        working-directory: ./server
         run: |
-          cd server
           mvn clean package -DskipTests
           mkdir -p ../client/server
           cp target/language-server-liquidjava.jar ../client/server/

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # Java related
 *.class
-# *.jar
+*.jar
 *.war
 *.ear
 *.nar

--- a/install.sh
+++ b/install.sh
@@ -24,9 +24,10 @@ cd server
 mvn clean package -DskipTests
 mkdir -p ../client/server
 cp target/language-server-liquidjava.jar ../client/server/
+cd ..
 
 # build and install vscode extension
-cd ../client
+cd client
 vsce package
 code --install-extension liquid-java-$VERSION.vsix
 cd ..

--- a/install.sh
+++ b/install.sh
@@ -19,7 +19,14 @@ if ! grep -q "\"version\": \"$VERSION\"" ./client/package.json; then
     exit 1
 fi
 
-cd client
+# build server jar
+cd server
+mvn clean package -DskipTests
+mkdir -p ../client/server
+cp target/language-server-liquidjava.jar ../client/server/
+
+# build and install vscode extension
+cd ../client
 vsce package
 code --install-extension liquid-java-$VERSION.vsix
 cd ..

--- a/install.sh
+++ b/install.sh
@@ -1,10 +1,16 @@
 #!/bin/bash
 VERSION=$1
+SKIP_SERVER=false
 
 # check if version argument provided
 if [ -z "$VERSION" ]; then
-    echo "Usage: $0 1.2.3"
+    echo "Usage: $0 1.2.3 [--skip-server]"
     exit 1
+fi
+
+# check for flags
+if [ "$2" == "--skip-server" ]; then
+    SKIP_SERVER=true
 fi
 
 # check valid version format
@@ -20,11 +26,13 @@ if ! grep -q "\"version\": \"$VERSION\"" ./client/package.json; then
 fi
 
 # build server jar
-cd server
-mvn clean package -DskipTests
-mkdir -p ../client/server
-cp target/language-server-liquidjava.jar ../client/server/
-cd ..
+if [ "$SKIP_SERVER" = false ]; then
+    cd server
+    mvn clean package -DskipTests
+    mkdir -p ../client/server
+    cp target/language-server-liquidjava.jar ../client/server/
+    cd ..
+fi
 
 # build and install vscode extension
 cd client

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -13,7 +13,7 @@
             </testResource>
         </testResources>
         <plugins>
-			<plugin>
+			<!-- <plugin>
 				<groupId>net.revelc.code.formatter</groupId>
 				<artifactId>formatter-maven-plugin</artifactId>
 				<version>2.16.0</version>
@@ -31,7 +31,7 @@
 					<compilerCompliance>20</compilerCompliance>
 					<compilerTargetPlatform>20</compilerTargetPlatform>
 				</configuration>
-			</plugin>
+			</plugin> -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>


### PR DESCRIPTION
This PR updates the `install.sh` script to automatically build the language server JAR using the `mvn package` command. This way, we don't have to manually build and move the JAR to the `client/server` directory. Also, by building the JAR in the publish workflow, we can remove it from the repository.