### PR TITLE
Autocomplete Improvements

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -18,15 +18,14 @@ import { runClient, stopClient } from "./lsp/client";
  */
 export async function activate(context: vscode.ExtensionContext) {
     registerLogger(context);
-    registerStatusBar(context);
-    registerCommands(context);
-    registerWebview(context);
-    registerEvents(context);
-    registerAutocomplete(context);
-    registerHover();
-
     extension.logger.client.info("Activating LiquidJava extension...");
     
+    registerStatusBar(context);
+    registerCommands(context);
+    registerEvents(context);
+    registerWebview(context);
+    registerAutocomplete(context);
+    registerHover();
     await applyItalicOverlay();
     await startExtension(context);
 }

--- a/client/src/services/autocomplete.ts
+++ b/client/src/services/autocomplete.ts
@@ -24,7 +24,7 @@ export function registerAutocomplete(context: vscode.ExtensionContext) {
 function getContextCompletionItems(context: ContextHistory, file: string, nextChar: string): vscode.CompletionItem[] {
     const variablesInScope = getVariablesInScope(file, extension.selection);
     const triggerParameterHints = nextChar !== "(";
-    const variableItems = getVariableCompletionItems([...variablesInScope, ...context.instanceVars, ...context.globalVars]);
+    const variableItems = getVariableCompletionItems([...variablesInScope, ...context.globalVars]); // not including instance vars
     const ghostItems = getGhostCompletionItems(context.ghosts, triggerParameterHints);
     const aliasItems = getAliasCompletionItems(context.aliases, triggerParameterHints);
     const keywordItems = getKeywordsCompletionItems(triggerParameterHints);
@@ -34,7 +34,7 @@ function getContextCompletionItems(context: ContextHistory, file: string, nextCh
     const uniqueItems = new Map<string, vscode.CompletionItem>();
     allItems.forEach(item => {
         const label = typeof item.label === "string" ? item.label : item.label.label;
-        if (!uniqueItems.has(label) && !label.startsWith("this#")) uniqueItems.set(label, item);
+        if (!uniqueItems.has(label)) uniqueItems.set(label, item);
     });
     return Array.from(uniqueItems.values());
 }
@@ -45,7 +45,6 @@ function getVariableCompletionItems(variables: Variable[]): vscode.CompletionIte
         const codeBlocks: string[] = [];
         if (variable.mainRefinement !== "true") codeBlocks.push(`@Refinement("${variable.mainRefinement}")`);
         codeBlocks.push(varSig);
-
         return createCompletionItem({
             name: variable.name,
             kind: vscode.CompletionItemKind.Variable,
@@ -59,14 +58,15 @@ function getVariableCompletionItems(variables: Variable[]): vscode.CompletionIte
 function getGhostCompletionItems(ghosts: Ghost[], triggerParameterHints: boolean): vscode.CompletionItem[] {
     return ghosts.map(ghost => {
         const parameters = ghost.parameterTypes.map(getSimpleName).join(", ");
-        const parametersStr = `(${parameters})`;
-        const ghostSig = `${ghost.returnType} ${ghost.name}${parametersStr}`;
+        const ghostSig = `${ghost.returnType} ${ghost.name}(${parameters})`;
+        const isState = /^state\d+\(_\) == \d+$/.test(ghost.refinement);
+        const description = isState ? "state" : "ghost";
         return createCompletionItem({
             name: ghost.name,
             kind: vscode.CompletionItemKind.Function,
-            labelDetail: parametersStr,
-            description: ghost.returnType,
-            detail: "ghost",
+            labelDetail: `(${parameters})`,
+            description,
+            detail: description,
             codeBlocks: [ghostSig],
             insertText: triggerParameterHints ? `${ghost.name}($1)` : ghost.name,
             triggerParameterHints,
@@ -81,15 +81,14 @@ function getAliasCompletionItems(aliases: Alias[], triggerParameterHints: boolea
                 const type = getSimpleName(alias.types[index]);
                 return `${type} ${parameter}`;
             }).join(", ");
-        const parametersStr = `(${parameters})`;
-        const aliasSig = `${alias.name}${parametersStr} { ${alias.predicate} }`;
-
+        const aliasSig = `${alias.name}(${parameters}) { ${alias.predicate} }`;
+        const description = "alias";
         return createCompletionItem({
             name: alias.name,
             kind: vscode.CompletionItemKind.Function,
-            labelDetail: parametersStr,
-            description: alias.predicate,
-            detail: "alias",
+            labelDetail: `(${parameters}){ ${alias.predicate} }`,
+            description,
+            detail: description,
             codeBlocks: [aliasSig],
             insertText: triggerParameterHints ? `${alias.name}($1)` : alias.name,
             triggerParameterHints,

--- a/client/src/services/autocomplete.ts
+++ b/client/src/services/autocomplete.ts
@@ -26,7 +26,9 @@ function getContextCompletionItems(context: ContextHistory, file: string, nextCh
     const inScope = variablesInScope !== null;
     const triggerParameterHints = nextChar !== "(";
     const variableItems = getVariableCompletionItems([...(variablesInScope || []), ...context.globalVars]); // not including instance vars
-    const ghostItems = getGhostCompletionItems(context.ghosts, triggerParameterHints);
+
+    const ghostsInFile = context.ghosts[file] || [];
+    const ghostItems = getGhostCompletionItems(ghostsInFile, triggerParameterHints);
     const aliasItems = getAliasCompletionItems(context.aliases, triggerParameterHints);
     const keywordItems = getKeywordsCompletionItems(triggerParameterHints, inScope);
     const allItems = [...variableItems, ...ghostItems, ...aliasItems, ...keywordItems];

--- a/client/src/services/autocomplete.ts
+++ b/client/src/services/autocomplete.ts
@@ -23,11 +23,12 @@ export function registerAutocomplete(context: vscode.ExtensionContext) {
 
 function getContextCompletionItems(context: ContextHistory, file: string, nextChar: string): vscode.CompletionItem[] {
     const variablesInScope = getVariablesInScope(file, extension.selection);
+    const inScope = variablesInScope !== null;
     const triggerParameterHints = nextChar !== "(";
-    const variableItems = getVariableCompletionItems([...variablesInScope, ...context.globalVars]); // not including instance vars
+    const variableItems = getVariableCompletionItems([...(variablesInScope || []), ...context.globalVars]); // not including instance vars
     const ghostItems = getGhostCompletionItems(context.ghosts, triggerParameterHints);
     const aliasItems = getAliasCompletionItems(context.aliases, triggerParameterHints);
-    const keywordItems = getKeywordsCompletionItems(triggerParameterHints);
+    const keywordItems = getKeywordsCompletionItems(triggerParameterHints, inScope);
     const allItems = [...variableItems, ...ghostItems, ...aliasItems, ...keywordItems];
     
     // remove duplicates
@@ -96,7 +97,7 @@ function getAliasCompletionItems(aliases: Alias[], triggerParameterHints: boolea
     });
 }
 
-function getKeywordsCompletionItems(triggerParameterHints: boolean): vscode.CompletionItem[] {
+function getKeywordsCompletionItems(triggerParameterHints: boolean, inScope: boolean): vscode.CompletionItem[] {
     const thisItem = createCompletionItem({
         name: "this",
         kind: vscode.CompletionItemKind.Keyword,
@@ -113,14 +114,18 @@ function getKeywordsCompletionItems(triggerParameterHints: boolean): vscode.Comp
         insertText: triggerParameterHints ? "old($1)" : "old",
         triggerParameterHints,
     });
-    const returnItem = createCompletionItem({
-        name: "return",
-        kind: vscode.CompletionItemKind.Keyword,
-        description: "",
-        detail: "keyword",
-        documentationBlocks: ["Keyword referring to the **method return value**"],
-    });
-    return [thisItem, oldItem, returnItem];
+    const items: vscode.CompletionItem[] = [thisItem, oldItem];
+    if (!inScope) {
+        const returnItem = createCompletionItem({
+            name: "return",
+            kind: vscode.CompletionItemKind.Keyword,
+            description: "",
+            detail: "keyword",
+            documentationBlocks: ["Keyword referring to the **method return value**"],
+        });
+        items.push(returnItem);
+    }
+    return items;
 }
 
 type CompletionItemOptions = {

--- a/client/src/services/autocomplete.ts
+++ b/client/src/services/autocomplete.ts
@@ -36,7 +36,7 @@ function getContextCompletionItems(context: ContextHistory, file: string, nextCh
     const uniqueItems = new Map<string, vscode.CompletionItem>();
     allItems.forEach(item => {
         const label = typeof item.label === "string" ? item.label : item.label.label;
-        if (!uniqueItems.has(label)) uniqueItems.set(label, item);
+        if (!uniqueItems.has(label) && !label.startsWith("this#")) uniqueItems.set(label, item);
     });
     return Array.from(uniqueItems.values());
 }

--- a/client/src/services/autocomplete.ts
+++ b/client/src/services/autocomplete.ts
@@ -24,19 +24,34 @@ type CompletionItemKind = "vars" | "ghosts" | "aliases" | "keywords" | "types" |
 export function registerAutocomplete(context: vscode.ExtensionContext) {
     context.subscriptions.push(
         vscode.languages.registerCompletionItemProvider("java", {
-            provideCompletionItems(document, position) {
+            provideCompletionItems(document, position, _token, completionContext) {
                 const annotation = getActiveLiquidJavaAnnotation(document, position);
                 if (!annotation || !extension.contextHistory) return null;
+
+                const isDotTrigger =  completionContext.triggerKind === vscode.CompletionTriggerKind.TriggerCharacter && completionContext.triggerCharacter === ".";
+                const receiver = isDotTrigger ? getReceiverBeforeDot(document, position) : null; 
                 const file = document.uri.toString().replace("file://", "");
                 const nextChar = document.getText(new vscode.Range(position, position.translate(0, 1)));
-                return getContextCompletionItems(extension.contextHistory, file, annotation, nextChar);
+                const items = getContextCompletionItems(extension.contextHistory, file, annotation, nextChar, isDotTrigger, receiver);
+                const uniqueItems = new Map<string, vscode.CompletionItem>();
+                items.forEach(item => {
+                    const label = typeof item.label === "string" ? item.label : item.label.label;
+                    if (!uniqueItems.has(label)) uniqueItems.set(label, item);
+                });
+                return Array.from(uniqueItems.values());
             },
-        })
+        }, '.', '"')
     );
 }
 
-function getContextCompletionItems(context: ContextHistory, file: string, annotation: LJAnnotation, nextChar: string): vscode.CompletionItem[] {   
+function getContextCompletionItems(context: ContextHistory, file: string, annotation: LJAnnotation, nextChar: string, isDotTrigger: boolean, receiver: string | null): vscode.CompletionItem[] {
     const triggerParameterHints = nextChar !== "(";
+    if (isDotTrigger) {
+        if (receiver === "this" || receiver === "old(this)") {
+            return getGhostCompletionItems(context.ghosts[file] || [], triggerParameterHints);
+        }
+        return [];
+    } 
     const variablesInScope = getVariablesInScope(file, extension.selection);
     const inScope = variablesInScope !== null;
     const itemsHandlers: Record<CompletionItemKind, () => vscode.CompletionItem[]> = {
@@ -46,7 +61,7 @@ function getContextCompletionItems(context: ContextHistory, file: string, annota
         keywords: () => getKeywordsCompletionItems(triggerParameterHints, inScope),
         types: () => getTypesCompletionItems(),
         decls: () => getDeclsCompletionItems(),
-        packages: () => [], // TODO: implement packages completion
+        packages: () => [], // TODO
     }
     const itemsMap: Record<LJAnnotation, CompletionItemKind[]> = {
         Refinement: ["vars", "ghosts", "aliases", "keywords"],
@@ -57,13 +72,7 @@ function getContextCompletionItems(context: ContextHistory, file: string, annota
         StateSet: [],
         ExternalRefinementsFor: ["packages"]
     }
-    const items: vscode.CompletionItem[] = itemsMap[annotation].map(key => itemsHandlers[key]()).flat();
-    const uniqueItems = new Map<string, vscode.CompletionItem>();
-    items.forEach(item => {
-        const label = typeof item.label === "string" ? item.label : item.label.label;
-        if (!uniqueItems.has(label)) uniqueItems.set(label, item);
-    });
-    return Array.from(uniqueItems.values());
+    return itemsMap[annotation].map(key => itemsHandlers[key]()).flat();
 }
 
 function getVariableCompletionItems(variables: Variable[]): vscode.CompletionItem[] {
@@ -131,15 +140,7 @@ function getKeywordsCompletionItems(triggerParameterHints: boolean, inScope: boo
         detail: "keyword",
         documentationBlocks: ["Keyword referring to the **current instance**"],
     });
-    const oldItem = createCompletionItem({
-        name: "old",
-        kind: vscode.CompletionItemKind.Keyword,
-        description: "",
-        detail: "keyword",
-        documentationBlocks: ["Keyword referring to the **previous state of the current instance**"],
-        insertText: triggerParameterHints ? "old($1)" : "old",
-        triggerParameterHints,
-    });
+    const oldItem = getOldKeywordCompletionItem(triggerParameterHints);
     const trueItem = createCompletionItem({
         name: "true",
         kind: vscode.CompletionItemKind.Keyword,
@@ -165,6 +166,18 @@ function getKeywordsCompletionItems(triggerParameterHints: boolean, inScope: boo
         items.push(returnItem);
     }
     return items;
+}
+
+function getOldKeywordCompletionItem(triggerParameterHints: boolean): vscode.CompletionItem {
+    return createCompletionItem({
+        name: "old",
+        kind: vscode.CompletionItemKind.Keyword,
+        description: "",
+        detail: "keyword",
+        documentationBlocks: ["Keyword referring to the **previous state of the current instance**"],
+        insertText: triggerParameterHints ? "old($1)" : "old",
+        triggerParameterHints,
+    });
 }
 
 function getTypesCompletionItems(): vscode.CompletionItem[] {
@@ -229,4 +242,13 @@ function getActiveLiquidJavaAnnotation(document: vscode.TextDocument, position: 
         if (char === ")") parenthesisDepth--;
     }
     return parenthesisDepth > 0 ? lastAnnotationName : null;
+}
+
+function getReceiverBeforeDot(document: vscode.TextDocument, position: vscode.Position): string | null {
+    const prefix = document.lineAt(position.line).text.slice(0, position.character);
+    const match = prefix.match(/((?:old\s*\(\s*this\s*\))|(?:[A-Za-z_]\w*))\.\w*$/);
+    if (!match) return null;
+    const receiver = match[1].trim();
+    if (/^old\s*\(\s*this\s*\)$/.test(receiver)) return "old(this)";
+    return receiver;
 }

--- a/client/src/services/autocomplete.ts
+++ b/client/src/services/autocomplete.ts
@@ -118,6 +118,7 @@ function getKeywordsCompletionItems(): vscode.CompletionItem[] {
         description: "",
         detail: "keyword",
         documentationBlocks: ["Keyword referring to the **previous state of the current instance**"],
+        insertText: "old($1)",
         triggerParameterHints: true,
     });
     const resultItem = createCompletionItem({

--- a/client/src/services/autocomplete.ts
+++ b/client/src/services/autocomplete.ts
@@ -1,11 +1,9 @@
 import * as vscode from "vscode";
 import { extension } from "../state";
 import type { Variable, ContextHistory, Ghost, Alias } from "../types/context";
-import { LIQUIDJAVA_ANNOTATIONS } from "../utils/constants";
 import { getSimpleName } from "../utils/utils";
 import { getVariablesInScope } from "./context";
-
-const LIQUIDJAVA_ANNOTATION_START = new RegExp(`@(liquidjava\\.specification\\.)?(${LIQUIDJAVA_ANNOTATIONS.join("|")})\\s*\\(`, "g");
+import { LIQUIDJAVA_ANNOTATION_START } from "../utils/constants";
 
 /**
  * Registers a completion provider for LiquidJava annotations, providing context-aware suggestions based on the current context history
@@ -162,14 +160,13 @@ function isInsideLiquidJavaAnnotationString(document: vscode.TextDocument, posit
         lastAnnotationStart = match.index;
     }
     if (lastAnnotationStart === -1) return false;
+    
     const fromLastAnnotation = textUntilCursor.slice(lastAnnotationStart);
-
     let parenthesisDepth = 0;
     let isInsideString = false;
     for (let i = 0; i < fromLastAnnotation.length; i++) {
         const char = fromLastAnnotation[i];
         const previousChar = i > 0 ? fromLastAnnotation[i - 1] : "";
-
         if (char === '"' && previousChar !== "\\") {
             isInsideString = !isInsideString;
             continue;

--- a/client/src/services/autocomplete.ts
+++ b/client/src/services/autocomplete.ts
@@ -3,7 +3,20 @@ import { extension } from "../state";
 import type { Variable, ContextHistory, Ghost, Alias } from "../types/context";
 import { getSimpleName } from "../utils/utils";
 import { getVariablesInScope } from "./context";
-import { LIQUIDJAVA_ANNOTATION_START } from "../utils/constants";
+import { LIQUIDJAVA_ANNOTATION_START, LJAnnotation } from "../utils/constants";
+
+type CompletionItemOptions = {
+    name: string;
+    kind: vscode.CompletionItemKind;
+    description?: string;
+    labelDetail?: string;
+    detail: string;
+    documentationBlocks?: string[];
+    codeBlocks?: string[];
+    insertText?: string;
+    triggerParameterHints?: boolean;
+}
+type CompletionItemKind = "vars" | "ghosts" | "aliases" | "keywords" | "types" | "decls" | "imports";
 
 /**
  * Registers a completion provider for LiquidJava annotations, providing context-aware suggestions based on the current context history
@@ -12,30 +25,41 @@ export function registerAutocomplete(context: vscode.ExtensionContext) {
     context.subscriptions.push(
         vscode.languages.registerCompletionItemProvider("java", {
             provideCompletionItems(document, position) {
-                if (!isInsideLiquidJavaAnnotationString(document, position) || !extension.contextHistory) return null;
+                const annotation = getActiveLiquidJavaAnnotation(document, position);
+                if (!annotation || !extension.contextHistory) return null;
                 const file = document.uri.toString().replace("file://", "");
                 const nextChar = document.getText(new vscode.Range(position, position.translate(0, 1)));
-                return getContextCompletionItems(extension.contextHistory, file, nextChar);
+                return getContextCompletionItems(extension.contextHistory, file, annotation, nextChar);
             },
         })
     );
 }
 
-function getContextCompletionItems(context: ContextHistory, file: string, nextChar: string): vscode.CompletionItem[] {
+function getContextCompletionItems(context: ContextHistory, file: string, annotation: LJAnnotation, nextChar: string): vscode.CompletionItem[] {   
+    const triggerParameterHints = nextChar !== "(";
     const variablesInScope = getVariablesInScope(file, extension.selection);
     const inScope = variablesInScope !== null;
-    const triggerParameterHints = nextChar !== "(";
-    const variableItems = getVariableCompletionItems([...(variablesInScope || []), ...context.globalVars]); // not including instance vars
-
-    const ghostsInFile = context.ghosts[file] || [];
-    const ghostItems = getGhostCompletionItems(ghostsInFile, triggerParameterHints);
-    const aliasItems = getAliasCompletionItems(context.aliases, triggerParameterHints);
-    const keywordItems = getKeywordsCompletionItems(triggerParameterHints, inScope);
-    const allItems = [...variableItems, ...ghostItems, ...aliasItems, ...keywordItems];
-    
-    // remove duplicates
+    const itemsHandlers: Record<CompletionItemKind, () => vscode.CompletionItem[]> = {
+        vars: () => getVariableCompletionItems(variablesInScope || []),
+        ghosts: () => getGhostCompletionItems(context.ghosts[file] || [], triggerParameterHints),
+        aliases: () => getAliasCompletionItems(context.aliases, triggerParameterHints),
+        keywords: () => getKeywordsCompletionItems(triggerParameterHints, inScope),
+        types: () => getTypesCompletionItems(),
+        decls: () => getDeclsCompletionItems(),
+        imports: () => [], // TODO: implement imports completion
+    }
+    const itemsMap: Record<LJAnnotation, CompletionItemKind[]> = {
+        Refinement: ["vars", "ghosts", "aliases", "keywords"],
+        StateRefinement: ["vars", "ghosts", "aliases", "keywords"],
+        Ghost: ["types"],
+        RefinementAlias: ["types"],
+        RefinementPredicate: ["types", "decls"],
+        StateSet: [],
+        ExternalRefinementsFor: ["imports"]
+    }
+    const items: vscode.CompletionItem[] = itemsMap[annotation].map(key => itemsHandlers[key]()).flat();
     const uniqueItems = new Map<string, vscode.CompletionItem>();
-    allItems.forEach(item => {
+    items.forEach(item => {
         const label = typeof item.label === "string" ? item.label : item.label.label;
         if (!uniqueItems.has(label)) uniqueItems.set(label, item);
     });
@@ -116,7 +140,20 @@ function getKeywordsCompletionItems(triggerParameterHints: boolean, inScope: boo
         insertText: triggerParameterHints ? "old($1)" : "old",
         triggerParameterHints,
     });
-    const items: vscode.CompletionItem[] = [thisItem, oldItem];
+    const trueItem = createCompletionItem({
+        name: "true",
+        kind: vscode.CompletionItemKind.Keyword,
+        description: "",
+        detail: "keyword",
+    });
+
+    const falseItem = createCompletionItem({
+        name: "false",
+        kind: vscode.CompletionItemKind.Keyword,
+        description: "",
+        detail: "keyword",
+    });
+    const items: vscode.CompletionItem[] = [thisItem, oldItem, trueItem, falseItem];
     if (!inScope) {
         const returnItem = createCompletionItem({
             name: "return",
@@ -130,16 +167,24 @@ function getKeywordsCompletionItems(triggerParameterHints: boolean, inScope: boo
     return items;
 }
 
-type CompletionItemOptions = {
-    name: string;
-    kind: vscode.CompletionItemKind;
-    description?: string;
-    labelDetail?: string;
-    detail: string;
-    documentationBlocks?: string[];
-    codeBlocks?: string[];
-    insertText?: string;
-    triggerParameterHints?: boolean;
+function getTypesCompletionItems(): vscode.CompletionItem[] {
+    const types = ["int", "double", "float", "boolean"];
+    return types.map(type => createCompletionItem({
+        name: type,
+        kind: vscode.CompletionItemKind.Keyword,
+        description: "",
+        detail: "keyword",
+    }));
+}
+
+function getDeclsCompletionItems(): vscode.CompletionItem[] {
+    const decls = ["ghost", "type"]
+    return decls.map(decl => createCompletionItem({
+        name: decl,
+        kind: vscode.CompletionItemKind.Keyword,
+        description: "",
+        detail: "keyword",
+    }));
 }
 
 function createCompletionItem({ name, kind, labelDetail, description, detail, documentationBlocks, codeBlocks, insertText, triggerParameterHints }: CompletionItemOptions): vscode.CompletionItem {
@@ -157,15 +202,17 @@ function createCompletionItem({ name, kind, labelDetail, description, detail, do
     return item;
 }
 
-function isInsideLiquidJavaAnnotationString(document: vscode.TextDocument, position: vscode.Position): boolean {
+function getActiveLiquidJavaAnnotation(document: vscode.TextDocument, position: vscode.Position): LJAnnotation | null {
     const textUntilCursor = document.getText(new vscode.Range(new vscode.Position(0, 0), position));
     LIQUIDJAVA_ANNOTATION_START.lastIndex = 0;
     let match: RegExpExecArray | null = null;
     let lastAnnotationStart = -1;
+    let lastAnnotationName: LJAnnotation | null = null;
     while ((match = LIQUIDJAVA_ANNOTATION_START.exec(textUntilCursor)) !== null) {
         lastAnnotationStart = match.index;
+        lastAnnotationName = match[2] as LJAnnotation || null;
     }
-    if (lastAnnotationStart === -1) return false;
+    if (lastAnnotationStart === -1 || !lastAnnotationName) return null;
 
     const fromLastAnnotation = textUntilCursor.slice(lastAnnotationStart);
     let parenthesisDepth = 0;
@@ -181,5 +228,5 @@ function isInsideLiquidJavaAnnotationString(document: vscode.TextDocument, posit
         if (char === "(") parenthesisDepth++;
         if (char === ")") parenthesisDepth--;
     }
-    return parenthesisDepth > 0;
+    return parenthesisDepth > 0 ? lastAnnotationName : null;
 }

--- a/client/src/services/autocomplete.ts
+++ b/client/src/services/autocomplete.ts
@@ -16,7 +16,7 @@ type CompletionItemOptions = {
     insertText?: string;
     triggerParameterHints?: boolean;
 }
-type CompletionItemKind = "vars" | "ghosts" | "aliases" | "keywords" | "types" | "decls" | "imports";
+type CompletionItemKind = "vars" | "ghosts" | "aliases" | "keywords" | "types" | "decls" | "packages";
 
 /**
  * Registers a completion provider for LiquidJava annotations, providing context-aware suggestions based on the current context history
@@ -46,7 +46,7 @@ function getContextCompletionItems(context: ContextHistory, file: string, annota
         keywords: () => getKeywordsCompletionItems(triggerParameterHints, inScope),
         types: () => getTypesCompletionItems(),
         decls: () => getDeclsCompletionItems(),
-        imports: () => [], // TODO: implement imports completion
+        packages: () => [], // TODO: implement packages completion
     }
     const itemsMap: Record<LJAnnotation, CompletionItemKind[]> = {
         Refinement: ["vars", "ghosts", "aliases", "keywords"],
@@ -55,7 +55,7 @@ function getContextCompletionItems(context: ContextHistory, file: string, annota
         RefinementAlias: ["types"],
         RefinementPredicate: ["types", "decls"],
         StateSet: [],
-        ExternalRefinementsFor: ["imports"]
+        ExternalRefinementsFor: ["packages"]
     }
     const items: vscode.CompletionItem[] = itemsMap[annotation].map(key => itemsHandlers[key]()).flat();
     const uniqueItems = new Map<string, vscode.CompletionItem>();

--- a/client/src/services/autocomplete.ts
+++ b/client/src/services/autocomplete.ts
@@ -32,7 +32,8 @@ function getContextCompletionItems(context: ContextHistory, file: string): vscod
     const variableItems = getVariableCompletionItems(variablesInScope);
     const ghostItems = getGhostCompletionItems(context.ghosts);
     const aliasItems = getAliasCompletionItems(context.aliases);
-    const allItems = [...variableItems, ...ghostItems, ...aliasItems];
+    const keywordItems = getKeywordsCompletionItems();
+    const allItems = [...variableItems, ...ghostItems, ...aliasItems, ...keywordItems];
     
     // remove duplicates
     const uniqueItems = new Map<string, vscode.CompletionItem>();
@@ -48,16 +49,16 @@ function getContextCompletionItems(context: ContextHistory, file: string): vscod
 function getVariableCompletionItems(variables: Variable[]): vscode.CompletionItem[] {
     return variables.map(variable => {
         const varSig = `${variable.type} ${variable.name}`;
-        const documentationBlocks: string[] = [];
-        if (variable.mainRefinement !== "true") documentationBlocks.push(`@Refinement("${variable.mainRefinement}")`);
-        documentationBlocks.push(varSig);
+        const codeBlocks: string[] = [];
+        if (variable.mainRefinement !== "true") codeBlocks.push(`@Refinement("${variable.mainRefinement}")`);
+        codeBlocks.push(varSig);
 
         return createCompletionItem({
             name: variable.name,
             kind: vscode.CompletionItemKind.Variable,
             description: variable.type,
             detail: "variable",
-            documentationBlocks,
+            codeBlocks,
         });
     });
 }
@@ -73,7 +74,7 @@ function getGhostCompletionItems(ghosts: Ghost[]): vscode.CompletionItem[] {
             labelDetail: parametersStr,
             description: ghost.returnType,
             detail: "ghost",
-            documentationBlocks: [ghostSig],
+            codeBlocks: [ghostSig],
             insertText: `${ghost.name}($1)`,
             triggerParameterHints: true,
         });
@@ -96,11 +97,37 @@ function getAliasCompletionItems(aliases: Alias[]): vscode.CompletionItem[] {
             labelDetail: parametersStr,
             description: alias.predicate,
             detail: "alias",
-            documentationBlocks: [aliasSig],
+            codeBlocks: [aliasSig],
             insertText: `${alias.name}($1)`,
             triggerParameterHints: true,
         });
     });
+}
+
+function getKeywordsCompletionItems(): vscode.CompletionItem[] {
+    const thisItem = createCompletionItem({
+        name: "this",
+        kind: vscode.CompletionItemKind.Keyword,
+        description: "",
+        detail: "keyword",
+        documentationBlocks: ["Keyword referring to the **current instance**"],
+    });
+    const oldItem = createCompletionItem({
+        name: "old",
+        kind: vscode.CompletionItemKind.Keyword,
+        description: "",
+        detail: "keyword",
+        documentationBlocks: ["Keyword referring to the **previous state of the current instance**"],
+        triggerParameterHints: true,
+    });
+    const resultItem = createCompletionItem({
+        name: "return",
+        kind: vscode.CompletionItemKind.Keyword,
+        description: "",
+        detail: "keyword",
+        documentationBlocks: ["Keyword referring to the **method return value**"],
+    });
+    return [thisItem, oldItem, resultItem];
 }
 
 type CompletionItemOptions = {
@@ -109,12 +136,13 @@ type CompletionItemOptions = {
     description?: string;
     labelDetail?: string;
     detail: string;
-    documentationBlocks: string[];
+    documentationBlocks?: string[];
+    codeBlocks?: string[];
     insertText?: string;
     triggerParameterHints?: boolean;
 }
 
-function createCompletionItem({ name, kind, labelDetail, description, detail, documentationBlocks, insertText, triggerParameterHints }: CompletionItemOptions): vscode.CompletionItem {
+function createCompletionItem({ name, kind, labelDetail, description, detail, documentationBlocks, codeBlocks, insertText, triggerParameterHints }: CompletionItemOptions): vscode.CompletionItem {
     const item = new vscode.CompletionItem(name, kind);
     item.label = { label: name, detail: labelDetail, description };
     item.detail = detail;
@@ -122,8 +150,10 @@ function createCompletionItem({ name, kind, labelDetail, description, detail, do
     if (triggerParameterHints) item.command = { command: "editor.action.triggerParameterHints", title: "Trigger Parameter Hints" };
 
     const documentation = new vscode.MarkdownString();
-    documentationBlocks.forEach(block => documentation.appendCodeblock(block));
+    if (documentationBlocks) documentationBlocks.forEach(block => documentation.appendMarkdown(block));
+    if (codeBlocks) codeBlocks.forEach(block => documentation.appendCodeblock(block));  
     item.documentation = documentation;
+    
     return item;
 }
 
@@ -137,5 +167,20 @@ function isInsideLiquidJavaAnnotationString(document: vscode.TextDocument, posit
     }
     if (lastAnnotationStart === -1) return false;
     const fromLastAnnotation = textUntilCursor.slice(lastAnnotationStart);
-    return !fromLastAnnotation.includes(")");
+
+    let parenthesisDepth = 0;
+    let isInsideString = false;
+    for (let i = 0; i < fromLastAnnotation.length; i++) {
+        const char = fromLastAnnotation[i];
+        const previousChar = i > 0 ? fromLastAnnotation[i - 1] : "";
+
+        if (char === '"' && previousChar !== "\\") {
+            isInsideString = !isInsideString;
+            continue;
+        }
+        if (isInsideString) continue;
+        if (char === "(") parenthesisDepth++;
+        if (char === ")") parenthesisDepth--;
+    }
+    return parenthesisDepth > 0;
 }

--- a/client/src/services/autocomplete.ts
+++ b/client/src/services/autocomplete.ts
@@ -16,32 +16,27 @@ export function registerAutocomplete(context: vscode.ExtensionContext) {
             provideCompletionItems(document, position) {
                 if (!isInsideLiquidJavaAnnotationString(document, position) || !extension.contextHistory) return null;
                 const file = document.uri.toString().replace("file://", "");
-                return getContextCompletionItems(extension.contextHistory, file);
+                const nextChar = document.getText(new vscode.Range(position, position.translate(0, 1)));
+                return getContextCompletionItems(extension.contextHistory, file, nextChar);
             },
         })
     );
 }
 
-function getContextCompletionItems(context: ContextHistory, file: string): vscode.CompletionItem[] {
-    const variables: Variable[] = [];
+function getContextCompletionItems(context: ContextHistory, file: string, nextChar: string): vscode.CompletionItem[] {
     const variablesInScope = getVariablesInScope(file, extension.selection);
-    variables.push(...variablesInScope);
-    variables.push(...context.instanceVars);
-    variables.push(...context.globalVars);
-
-    const variableItems = getVariableCompletionItems(variablesInScope);
-    const ghostItems = getGhostCompletionItems(context.ghosts);
-    const aliasItems = getAliasCompletionItems(context.aliases);
-    const keywordItems = getKeywordsCompletionItems();
+    const triggerParameterHints = nextChar !== "(";
+    const variableItems = getVariableCompletionItems([...variablesInScope, ...context.instanceVars, ...context.globalVars]);
+    const ghostItems = getGhostCompletionItems(context.ghosts, triggerParameterHints);
+    const aliasItems = getAliasCompletionItems(context.aliases, triggerParameterHints);
+    const keywordItems = getKeywordsCompletionItems(triggerParameterHints);
     const allItems = [...variableItems, ...ghostItems, ...aliasItems, ...keywordItems];
     
     // remove duplicates
     const uniqueItems = new Map<string, vscode.CompletionItem>();
     allItems.forEach(item => {
         const label = typeof item.label === "string" ? item.label : item.label.label;
-        if (!uniqueItems.has(label)) {
-            uniqueItems.set(label, item);
-        }
+        if (!uniqueItems.has(label)) uniqueItems.set(label, item);
     });
     return Array.from(uniqueItems.values());
 }
@@ -63,7 +58,7 @@ function getVariableCompletionItems(variables: Variable[]): vscode.CompletionIte
     });
 }
 
-function getGhostCompletionItems(ghosts: Ghost[]): vscode.CompletionItem[] {
+function getGhostCompletionItems(ghosts: Ghost[], triggerParameterHints: boolean): vscode.CompletionItem[] {
     return ghosts.map(ghost => {
         const parameters = ghost.parameterTypes.map(getSimpleName).join(", ");
         const parametersStr = `(${parameters})`;
@@ -75,13 +70,13 @@ function getGhostCompletionItems(ghosts: Ghost[]): vscode.CompletionItem[] {
             description: ghost.returnType,
             detail: "ghost",
             codeBlocks: [ghostSig],
-            insertText: `${ghost.name}($1)`,
-            triggerParameterHints: true,
+            insertText: triggerParameterHints ? `${ghost.name}($1)` : ghost.name,
+            triggerParameterHints,
         });
     });
 }
 
-function getAliasCompletionItems(aliases: Alias[]): vscode.CompletionItem[] {
+function getAliasCompletionItems(aliases: Alias[], triggerParameterHints: boolean): vscode.CompletionItem[] {
     return aliases.map(alias => {
         const parameters = alias.parameters
             .map((parameter, index) => {
@@ -98,13 +93,13 @@ function getAliasCompletionItems(aliases: Alias[]): vscode.CompletionItem[] {
             description: alias.predicate,
             detail: "alias",
             codeBlocks: [aliasSig],
-            insertText: `${alias.name}($1)`,
-            triggerParameterHints: true,
+            insertText: triggerParameterHints ? `${alias.name}($1)` : alias.name,
+            triggerParameterHints,
         });
     });
 }
 
-function getKeywordsCompletionItems(): vscode.CompletionItem[] {
+function getKeywordsCompletionItems(triggerParameterHints: boolean): vscode.CompletionItem[] {
     const thisItem = createCompletionItem({
         name: "this",
         kind: vscode.CompletionItemKind.Keyword,
@@ -118,8 +113,8 @@ function getKeywordsCompletionItems(): vscode.CompletionItem[] {
         description: "",
         detail: "keyword",
         documentationBlocks: ["Keyword referring to the **previous state of the current instance**"],
-        insertText: "old($1)",
-        triggerParameterHints: true,
+        insertText: triggerParameterHints ? "old($1)" : "old",
+        triggerParameterHints,
     });
     const resultItem = createCompletionItem({
         name: "return",

--- a/client/src/services/autocomplete.ts
+++ b/client/src/services/autocomplete.ts
@@ -114,14 +114,14 @@ function getKeywordsCompletionItems(triggerParameterHints: boolean): vscode.Comp
         insertText: triggerParameterHints ? "old($1)" : "old",
         triggerParameterHints,
     });
-    const resultItem = createCompletionItem({
+    const returnItem = createCompletionItem({
         name: "return",
         kind: vscode.CompletionItemKind.Keyword,
         description: "",
         detail: "keyword",
         documentationBlocks: ["Keyword referring to the **method return value**"],
     });
-    return [thisItem, oldItem, resultItem];
+    return [thisItem, oldItem, returnItem];
 }
 
 type CompletionItemOptions = {
@@ -160,7 +160,7 @@ function isInsideLiquidJavaAnnotationString(document: vscode.TextDocument, posit
         lastAnnotationStart = match.index;
     }
     if (lastAnnotationStart === -1) return false;
-    
+
     const fromLastAnnotation = textUntilCursor.slice(lastAnnotationStart);
     let parenthesisDepth = 0;
     let isInsideString = false;

--- a/client/src/services/autocomplete.ts
+++ b/client/src/services/autocomplete.ts
@@ -1,9 +1,11 @@
 import * as vscode from "vscode";
 import { extension } from "../state";
 import type { Variable, ContextHistory, Ghost, Alias } from "../types/context";
+import { LIQUIDJAVA_ANNOTATIONS } from "../utils/constants";
 import { getSimpleName } from "../utils/utils";
 import { getVariablesInScope } from "./context";
-import { LIQUIDJAVA_ANNOTATION_START } from "../utils/constants";
+
+const LIQUIDJAVA_ANNOTATION_START = new RegExp(`@(liquidjava\\.specification\\.)?(${LIQUIDJAVA_ANNOTATIONS.join("|")})\\s*\\(`, "g");
 
 /**
  * Registers a completion provider for LiquidJava annotations, providing context-aware suggestions based on the current context history
@@ -14,28 +16,31 @@ export function registerAutocomplete(context: vscode.ExtensionContext) {
             provideCompletionItems(document, position) {
                 if (!isInsideLiquidJavaAnnotationString(document, position) || !extension.contextHistory) return null;
                 const file = document.uri.toString().replace("file://", "");
-                const nextChar = document.getText(new vscode.Range(position, position.translate(0, 1)));
-                return getContextCompletionItems(extension.contextHistory, file, nextChar);
+                return getContextCompletionItems(extension.contextHistory, file);
             },
         })
     );
 }
 
-function getContextCompletionItems(context: ContextHistory, file: string, nextChar: string): vscode.CompletionItem[] {
+function getContextCompletionItems(context: ContextHistory, file: string): vscode.CompletionItem[] {
+    const variables: Variable[] = [];
     const variablesInScope = getVariablesInScope(file, extension.selection);
-    const inScope = variablesInScope !== null;
-    const triggerParameterHints = nextChar !== "(";
-    const variableItems = getVariableCompletionItems([...(variablesInScope || []), ...context.globalVars]); // not including instance vars
-    const ghostItems = getGhostCompletionItems(context.ghosts, triggerParameterHints);
-    const aliasItems = getAliasCompletionItems(context.aliases, triggerParameterHints);
-    const keywordItems = getKeywordsCompletionItems(triggerParameterHints, inScope);
-    const allItems = [...variableItems, ...ghostItems, ...aliasItems, ...keywordItems];
+    variables.push(...variablesInScope);
+    variables.push(...context.instanceVars);
+    variables.push(...context.globalVars);
+
+    const variableItems = getVariableCompletionItems(variablesInScope);
+    const ghostItems = getGhostCompletionItems(context.ghosts);
+    const aliasItems = getAliasCompletionItems(context.aliases);
+    const allItems = [...variableItems, ...ghostItems, ...aliasItems];
     
     // remove duplicates
     const uniqueItems = new Map<string, vscode.CompletionItem>();
     allItems.forEach(item => {
         const label = typeof item.label === "string" ? item.label : item.label.label;
-        if (!uniqueItems.has(label)) uniqueItems.set(label, item);
+        if (!uniqueItems.has(label)) {
+            uniqueItems.set(label, item);
+        }
     });
     return Array.from(uniqueItems.values());
 }
@@ -43,89 +48,59 @@ function getContextCompletionItems(context: ContextHistory, file: string, nextCh
 function getVariableCompletionItems(variables: Variable[]): vscode.CompletionItem[] {
     return variables.map(variable => {
         const varSig = `${variable.type} ${variable.name}`;
-        const codeBlocks: string[] = [];
-        if (variable.mainRefinement !== "true") codeBlocks.push(`@Refinement("${variable.mainRefinement}")`);
-        codeBlocks.push(varSig);
+        const documentationBlocks: string[] = [];
+        if (variable.mainRefinement !== "true") documentationBlocks.push(`@Refinement("${variable.mainRefinement}")`);
+        documentationBlocks.push(varSig);
+
         return createCompletionItem({
             name: variable.name,
             kind: vscode.CompletionItemKind.Variable,
             description: variable.type,
             detail: "variable",
-            codeBlocks,
+            documentationBlocks,
         });
     });
 }
 
-function getGhostCompletionItems(ghosts: Ghost[], triggerParameterHints: boolean): vscode.CompletionItem[] {
+function getGhostCompletionItems(ghosts: Ghost[]): vscode.CompletionItem[] {
     return ghosts.map(ghost => {
         const parameters = ghost.parameterTypes.map(getSimpleName).join(", ");
-        const ghostSig = `${ghost.returnType} ${ghost.name}(${parameters})`;
-        const isState = /^state\d+\(_\) == \d+$/.test(ghost.refinement);
-        const description = isState ? "state" : "ghost";
+        const parametersStr = `(${parameters})`;
+        const ghostSig = `${ghost.returnType} ${ghost.name}${parametersStr}`;
         return createCompletionItem({
             name: ghost.name,
             kind: vscode.CompletionItemKind.Function,
-            labelDetail: `(${parameters})`,
-            description,
-            detail: description,
-            codeBlocks: [ghostSig],
-            insertText: triggerParameterHints ? `${ghost.name}($1)` : ghost.name,
-            triggerParameterHints,
+            labelDetail: parametersStr,
+            description: ghost.returnType,
+            detail: "ghost",
+            documentationBlocks: [ghostSig],
+            insertText: `${ghost.name}($1)`,
+            triggerParameterHints: true,
         });
     });
 }
 
-function getAliasCompletionItems(aliases: Alias[], triggerParameterHints: boolean): vscode.CompletionItem[] {
+function getAliasCompletionItems(aliases: Alias[]): vscode.CompletionItem[] {
     return aliases.map(alias => {
         const parameters = alias.parameters
             .map((parameter, index) => {
                 const type = getSimpleName(alias.types[index]);
                 return `${type} ${parameter}`;
             }).join(", ");
-        const aliasSig = `${alias.name}(${parameters}) { ${alias.predicate} }`;
-        const description = "alias";
+        const parametersStr = `(${parameters})`;
+        const aliasSig = `${alias.name}${parametersStr} { ${alias.predicate} }`;
+
         return createCompletionItem({
             name: alias.name,
             kind: vscode.CompletionItemKind.Function,
-            labelDetail: `(${parameters}){ ${alias.predicate} }`,
-            description,
-            detail: description,
-            codeBlocks: [aliasSig],
-            insertText: triggerParameterHints ? `${alias.name}($1)` : alias.name,
-            triggerParameterHints,
+            labelDetail: parametersStr,
+            description: alias.predicate,
+            detail: "alias",
+            documentationBlocks: [aliasSig],
+            insertText: `${alias.name}($1)`,
+            triggerParameterHints: true,
         });
     });
-}
-
-function getKeywordsCompletionItems(triggerParameterHints: boolean, inScope: boolean): vscode.CompletionItem[] {
-    const thisItem = createCompletionItem({
-        name: "this",
-        kind: vscode.CompletionItemKind.Keyword,
-        description: "",
-        detail: "keyword",
-        documentationBlocks: ["Keyword referring to the **current instance**"],
-    });
-    const oldItem = createCompletionItem({
-        name: "old",
-        kind: vscode.CompletionItemKind.Keyword,
-        description: "",
-        detail: "keyword",
-        documentationBlocks: ["Keyword referring to the **previous state of the current instance**"],
-        insertText: triggerParameterHints ? "old($1)" : "old",
-        triggerParameterHints,
-    });
-    const items: vscode.CompletionItem[] = [thisItem, oldItem];
-    if (!inScope) {
-        const returnItem = createCompletionItem({
-            name: "return",
-            kind: vscode.CompletionItemKind.Keyword,
-            description: "",
-            detail: "keyword",
-            documentationBlocks: ["Keyword referring to the **method return value**"],
-        });
-        items.push(returnItem);
-    }
-    return items;
 }
 
 type CompletionItemOptions = {
@@ -134,13 +109,12 @@ type CompletionItemOptions = {
     description?: string;
     labelDetail?: string;
     detail: string;
-    documentationBlocks?: string[];
-    codeBlocks?: string[];
+    documentationBlocks: string[];
     insertText?: string;
     triggerParameterHints?: boolean;
 }
 
-function createCompletionItem({ name, kind, labelDetail, description, detail, documentationBlocks, codeBlocks, insertText, triggerParameterHints }: CompletionItemOptions): vscode.CompletionItem {
+function createCompletionItem({ name, kind, labelDetail, description, detail, documentationBlocks, insertText, triggerParameterHints }: CompletionItemOptions): vscode.CompletionItem {
     const item = new vscode.CompletionItem(name, kind);
     item.label = { label: name, detail: labelDetail, description };
     item.detail = detail;
@@ -148,10 +122,8 @@ function createCompletionItem({ name, kind, labelDetail, description, detail, do
     if (triggerParameterHints) item.command = { command: "editor.action.triggerParameterHints", title: "Trigger Parameter Hints" };
 
     const documentation = new vscode.MarkdownString();
-    if (documentationBlocks) documentationBlocks.forEach(block => documentation.appendMarkdown(block));
-    if (codeBlocks) codeBlocks.forEach(block => documentation.appendCodeblock(block));  
+    documentationBlocks.forEach(block => documentation.appendCodeblock(block));
     item.documentation = documentation;
-    
     return item;
 }
 
@@ -164,20 +136,6 @@ function isInsideLiquidJavaAnnotationString(document: vscode.TextDocument, posit
         lastAnnotationStart = match.index;
     }
     if (lastAnnotationStart === -1) return false;
-
     const fromLastAnnotation = textUntilCursor.slice(lastAnnotationStart);
-    let parenthesisDepth = 0;
-    let isInsideString = false;
-    for (let i = 0; i < fromLastAnnotation.length; i++) {
-        const char = fromLastAnnotation[i];
-        const previousChar = i > 0 ? fromLastAnnotation[i - 1] : "";
-        if (char === '"' && previousChar !== "\\") {
-            isInsideString = !isInsideString;
-            continue;
-        }
-        if (isInsideString) continue;
-        if (char === "(") parenthesisDepth++;
-        if (char === ")") parenthesisDepth--;
-    }
-    return parenthesisDepth > 0;
+    return !fromLastAnnotation.includes(")");
 }

--- a/client/src/services/context.ts
+++ b/client/src/services/context.ts
@@ -30,7 +30,8 @@ export function getVariablesInScope(file: string, selection: Selection): Variabl
     const variablesInScope = mostSpecificScope ? fileVars[mostSpecificScope] : [];
 
     // filter variables to only include those that are reachable based on their position
-    return getReachableVariables(variablesInScope, selection);
+    const reachableVariables = getReachableVariables(variablesInScope, selection);
+    return reachableVariables.filter(v => !v.name.startsWith("this#"))
 }
 
 function parseScopeString(scope: string): Selection {

--- a/client/src/services/context.ts
+++ b/client/src/services/context.ts
@@ -5,12 +5,14 @@ export function handleContextHistory(contextHistory: ContextHistory) {
     extension.contextHistory = contextHistory;
 }
 
-export function getVariablesInScope(file: string, selection: Selection): Variable[] {
-    if (!extension.contextHistory || !selection || !file) return [];
+// Gets the variables in scope for a given file and position
+// Returns null if position not in any scope
+export function getVariablesInScope(file: string, selection: Selection): Variable[] | null {
+    if (!extension.contextHistory || !selection || !file) return null;
 
     // get variables in file
     const fileVars = extension.contextHistory.vars[file];
-    if (!fileVars) return [];
+    if (!fileVars) return null;
 
     // get variables in the current scope based on the selection
     let mostSpecificScope: string | null = null;
@@ -27,11 +29,13 @@ export function getVariablesInScope(file: string, selection: Selection): Variabl
             }
         }
     }
-    const variablesInScope = mostSpecificScope ? fileVars[mostSpecificScope] : [];
+    if (mostSpecificScope === null)
+        return null;
 
     // filter variables to only include those that are reachable based on their position
+    const variablesInScope = fileVars[mostSpecificScope];
     const reachableVariables = getReachableVariables(variablesInScope, selection);
-    return reachableVariables.filter(v => !v.name.startsWith("this#"))
+    return reachableVariables.filter(v => !v.name.startsWith("this#"));
 }
 
 function parseScopeString(scope: string): Selection {

--- a/client/src/services/context.ts
+++ b/client/src/services/context.ts
@@ -5,14 +5,12 @@ export function handleContextHistory(contextHistory: ContextHistory) {
     extension.contextHistory = contextHistory;
 }
 
-// Gets the variables in scope for a given file and position
-// Returns null if position not in any scope
-export function getVariablesInScope(file: string, selection: Selection): Variable[] | null {
-    if (!extension.contextHistory || !selection || !file) return null;
+export function getVariablesInScope(file: string, selection: Selection): Variable[] {
+    if (!extension.contextHistory || !selection || !file) return [];
 
     // get variables in file
     const fileVars = extension.contextHistory.vars[file];
-    if (!fileVars) return null;
+    if (!fileVars) return [];
 
     // get variables in the current scope based on the selection
     let mostSpecificScope: string | null = null;
@@ -29,13 +27,10 @@ export function getVariablesInScope(file: string, selection: Selection): Variabl
             }
         }
     }
-    if (mostSpecificScope === null)
-        return null;
+    const variablesInScope = mostSpecificScope ? fileVars[mostSpecificScope] : [];
 
     // filter variables to only include those that are reachable based on their position
-    const variablesInScope = fileVars[mostSpecificScope];
-    const reachableVariables = getReachableVariables(variablesInScope, selection);
-    return reachableVariables.filter(v => !v.name.startsWith("this#"));
+    return getReachableVariables(variablesInScope, selection);
 }
 
 function parseScopeString(scope: string): Selection {

--- a/client/src/services/context.ts
+++ b/client/src/services/context.ts
@@ -56,7 +56,7 @@ function isSelectionWithinScope(selection: Selection, scope: Selection): boolean
 function getReachableVariables(variables: Variable[], selection: Selection): Variable[] {
     return variables.filter((variable) => {
         const placement = variable.placementInCode?.position;
-        if (!placement) return true;
+        if (!placement || variable.isParameter) return true; // if is parameter we need to access it even if it's declared after the selection (for method and parameter refinements)
         return placement.line < selection.startLine || (placement.line === selection.startLine && placement.column <= selection.startColumn);
     });
 }

--- a/client/src/services/context.ts
+++ b/client/src/services/context.ts
@@ -56,7 +56,10 @@ function isSelectionWithinScope(selection: Selection, scope: Selection): boolean
 function getReachableVariables(variables: Variable[], selection: Selection): Variable[] {
     return variables.filter((variable) => {
         const placement = variable.placementInCode?.position;
-        if (!placement || variable.isParameter) return true; // if is parameter we need to access it even if it's declared after the selection (for method and parameter refinements)
-        return placement.line < selection.startLine || (placement.line === selection.startLine && placement.column <= selection.startColumn);
+        const startPosition = variable.annPosition || placement;
+        if (!startPosition || variable.isParameter) return true; // if is parameter we need to access it even if it's declared after the selection (for method and parameter refinements)
+        
+        // variable was declared before the cursor line or its in the same line but before the cursor column
+        return startPosition.line < selection.startLine || startPosition.line === selection.startLine && startPosition.column <= selection.startColumn;
     });
 }

--- a/client/src/services/events.ts
+++ b/client/src/services/events.ts
@@ -2,10 +2,10 @@ import * as vscode from 'vscode';
 import { extension } from '../state';
 import { updateStateMachine } from './state-machine';
 import { Selection } from '../types/context';
-import { SELECTION_DEBOUNCE_MS } from '../utils/constants';
 
 let selectionTimeout: NodeJS.Timeout | null = null;
 let currentSelection: Selection = { startLine: 0, startColumn: 0, endLine: 0, endColumn: 0 };
+const SELECTION_DEBOUNCE_TIME = 250; // ms
 
 /**
  * Initializes file system event listeners
@@ -56,5 +56,7 @@ export async function onSelectionChange(event: vscode.TextEditorSelectionChangeE
     };
     // debounce selection changes
     if (selectionTimeout) clearTimeout(selectionTimeout);
-    selectionTimeout = setTimeout(() => extension.selection = currentSelection, SELECTION_DEBOUNCE_MS);
+    selectionTimeout = setTimeout(() => {
+        extension.selection = currentSelection;
+    }, SELECTION_DEBOUNCE_TIME);
 }

--- a/client/src/services/events.ts
+++ b/client/src/services/events.ts
@@ -2,10 +2,10 @@ import * as vscode from 'vscode';
 import { extension } from '../state';
 import { updateStateMachine } from './state-machine';
 import { Selection } from '../types/context';
+import { SELECTION_DEBOUNCE_MS } from '../utils/constants';
 
 let selectionTimeout: NodeJS.Timeout | null = null;
 let currentSelection: Selection = { startLine: 0, startColumn: 0, endLine: 0, endColumn: 0 };
-const SELECTION_DEBOUNCE_TIME = 250; // ms
 
 /**
  * Initializes file system event listeners
@@ -56,7 +56,5 @@ export async function onSelectionChange(event: vscode.TextEditorSelectionChangeE
     };
     // debounce selection changes
     if (selectionTimeout) clearTimeout(selectionTimeout);
-    selectionTimeout = setTimeout(() => {
-        extension.selection = currentSelection;
-    }, SELECTION_DEBOUNCE_TIME);
+    selectionTimeout = setTimeout(() => extension.selection = currentSelection, SELECTION_DEBOUNCE_MS);
 }

--- a/client/src/types/context.ts
+++ b/client/src/types/context.ts
@@ -1,4 +1,4 @@
-import { PlacementInCode } from "./diagnostics";
+import { PlacementInCode, SourcePosition } from "./diagnostics";
 
 // Type definitions used for LiquidJava context information
 
@@ -9,6 +9,7 @@ export type Variable = {
   mainRefinement: string;
   placementInCode: PlacementInCode | null;
   isParameter: boolean;
+  annPosition: SourcePosition | null;
 }
 
 export type Ghost = {

--- a/client/src/types/context.ts
+++ b/client/src/types/context.ts
@@ -27,9 +27,9 @@ export type Alias = {
 
 export type ContextHistory = {
   vars: Record<string, Record<string, Variable[]>>; // file -> (scope -> variables in scope)
+  ghosts: Record<string, Ghost[]>; // file -> ghosts in file
   instanceVars: Variable[];
   globalVars: Variable[];
-  ghosts: Ghost[];
   aliases: Alias[];
 }
 

--- a/client/src/types/context.ts
+++ b/client/src/types/context.ts
@@ -8,6 +8,7 @@ export type Variable = {
   refinement: string;
   mainRefinement: string;
   placementInCode: PlacementInCode | null;
+  isParameter: boolean;
 }
 
 export type Ghost = {

--- a/client/src/types/diagnostics.ts
+++ b/client/src/types/diagnostics.ts
@@ -9,7 +9,7 @@ export type ErrorPosition = {
     colEnd: number;
 }
 
-export type Position = {
+export type SourcePosition = {
     file: string;
     line: number;
     column: number;
@@ -17,7 +17,7 @@ export type Position = {
 
 export type PlacementInCode = {
     text: string;
-    position: Position;
+    position: SourcePosition;
 }
 
 export type TranslationTable = Record<string, PlacementInCode>;

--- a/client/src/utils/constants.ts
+++ b/client/src/utils/constants.ts
@@ -2,7 +2,6 @@ export const SERVER_JAR = "language-server-liquidjava.jar";
 export const JAVA_BINARY = "java";
 export const DEBUG_MODE = false;
 export const DEBUG_PORT = 50000;
-export const SELECTION_DEBOUNCE_MS = 250;
 export const LIQUIDJAVA_SCOPES = [
     "source.liquidjava keyword.other.liquidjava",
     "source.liquidjava entity.name.function.liquidjava",
@@ -27,4 +26,3 @@ export const LIQUIDJAVA_ANNOTATIONS = [
     "StateRefinement",
     "ExternalRefinementsFor",
 ]
-export const LIQUIDJAVA_ANNOTATION_START = new RegExp(`@(liquidjava\\.specification\\.)?(${LIQUIDJAVA_ANNOTATIONS.join("|")})\\s*\\(`, "g");

--- a/client/src/utils/constants.ts
+++ b/client/src/utils/constants.ts
@@ -28,3 +28,4 @@ export const LIQUIDJAVA_ANNOTATIONS = [
     "ExternalRefinementsFor",
 ]
 export const LIQUIDJAVA_ANNOTATION_START = new RegExp(`@(liquidjava\\.specification\\.)?(${LIQUIDJAVA_ANNOTATIONS.join("|")})\\s*\\(`, "g");
+export type LJAnnotation = "Refinement" | "RefinementAlias" | "RefinementPredicate" | "StateSet" | "Ghost" | "StateRefinement" | "ExternalRefinementsFor";

--- a/client/src/utils/constants.ts
+++ b/client/src/utils/constants.ts
@@ -2,6 +2,7 @@ export const SERVER_JAR = "language-server-liquidjava.jar";
 export const JAVA_BINARY = "java";
 export const DEBUG_MODE = false;
 export const DEBUG_PORT = 50000;
+export const SELECTION_DEBOUNCE_MS = 250;
 export const LIQUIDJAVA_SCOPES = [
     "source.liquidjava keyword.other.liquidjava",
     "source.liquidjava entity.name.function.liquidjava",
@@ -26,3 +27,4 @@ export const LIQUIDJAVA_ANNOTATIONS = [
     "StateRefinement",
     "ExternalRefinementsFor",
 ]
+export const LIQUIDJAVA_ANNOTATION_START = new RegExp(`@(liquidjava\\.specification\\.)?(${LIQUIDJAVA_ANNOTATIONS.join("|")})\\s*\\(`, "g");

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -169,13 +169,6 @@
 	</dependencyManagement>
 	
 	<dependencies>
-		<!-- <dependency>
-			<groupId>liquidjava</groupId>
-			<artifactId>verifier</artifactId>
-			<version>0.0.13</version>
-			<scope>system</scope>
-			<systemPath>${project.basedir}/libs/liquidjava-verifier.jar</systemPath>
-		</dependency> -->
 		<dependency>
 			<groupId>io.github.liquid-java</groupId>
 			<artifactId>liquidjava-verifier</artifactId>

--- a/server/src/main/java/dtos/context/ContextHistoryDTO.java
+++ b/server/src/main/java/dtos/context/ContextHistoryDTO.java
@@ -12,7 +12,7 @@ public record ContextHistoryDTO(
     Map<String, Map<String, List<VariableDTO>>> vars,
     List<VariableDTO> instanceVars,
     List<VariableDTO> globalVars,
-    List<GhostDTO> ghosts,
+    Map<String, List<GhostDTO>> ghosts,
     List<AliasDTO> aliases
 ) {
     public static String stringifyType(CtTypeReference<?> typeReference) {

--- a/server/src/main/java/dtos/context/VariableDTO.java
+++ b/server/src/main/java/dtos/context/VariableDTO.java
@@ -11,7 +11,8 @@ public record VariableDTO(
     String type,
     String refinement,
     String mainRefinement,
-    PlacementInCodeDTO placementInCode
+    PlacementInCodeDTO placementInCode,
+    boolean isParameter
 ) {
     public static VariableDTO from(RefinedVariable refinedVariable) {
         return new VariableDTO(
@@ -19,7 +20,8 @@ public record VariableDTO(
             ContextHistoryDTO.stringifyType(refinedVariable.getType()),
             refinedVariable.getRefinement().toString(),
             refinedVariable.getMainRefinement().toString(),
-            PlacementInCodeDTO.from(refinedVariable.getPlacementInCode())
+            PlacementInCodeDTO.from(refinedVariable.getPlacementInCode()),
+            refinedVariable.isParameter()
         );
     }
 }

--- a/server/src/main/java/dtos/context/VariableDTO.java
+++ b/server/src/main/java/dtos/context/VariableDTO.java
@@ -1,6 +1,7 @@
 package dtos.context;
 
 import dtos.diagnostics.PlacementInCodeDTO;
+import dtos.diagnostics.SourcePositionDTO;
 import liquidjava.processor.context.RefinedVariable;
 
 /**
@@ -12,7 +13,8 @@ public record VariableDTO(
     String refinement,
     String mainRefinement,
     PlacementInCodeDTO placementInCode,
-    boolean isParameter
+    boolean isParameter,
+    SourcePositionDTO annPosition
 ) {
     public static VariableDTO from(RefinedVariable refinedVariable) {
         return new VariableDTO(
@@ -21,7 +23,8 @@ public record VariableDTO(
             refinedVariable.getRefinement().toString(),
             refinedVariable.getMainRefinement().toString(),
             PlacementInCodeDTO.from(refinedVariable.getPlacementInCode()),
-            refinedVariable.isParameter()
+            refinedVariable.isParameter(),
+            SourcePositionDTO.from(refinedVariable.getAnnPosition())
         );
     }
 }

--- a/server/src/main/java/dtos/context/VariableDTO.java
+++ b/server/src/main/java/dtos/context/VariableDTO.java
@@ -2,7 +2,6 @@ package dtos.context;
 
 import dtos.diagnostics.PlacementInCodeDTO;
 import liquidjava.processor.context.RefinedVariable;
-import spoon.reflect.reference.CtTypeReference;
 
 /**
  * DTO for serializing RefinedVariable instances to JSON.

--- a/server/src/main/java/dtos/diagnostics/PlacementInCodeDTO.java
+++ b/server/src/main/java/dtos/diagnostics/PlacementInCodeDTO.java
@@ -5,11 +5,11 @@ import liquidjava.processor.context.PlacementInCode;
 /**
  * DTO for serializing PlacementInCode instances to JSON
  */
-public record PlacementInCodeDTO(String text, PositionDTO position) {
+public record PlacementInCodeDTO(String text, SourcePositionDTO position) {
 
     public static PlacementInCodeDTO from(PlacementInCode placement) {
         if (placement == null)
             return null;
-        return new PlacementInCodeDTO(placement.getText(), PositionDTO.from(placement.getPosition()));
+        return new PlacementInCodeDTO(placement.getText(), SourcePositionDTO.from(placement.getPosition()));
     }
 }

--- a/server/src/main/java/dtos/diagnostics/SourcePositionDTO.java
+++ b/server/src/main/java/dtos/diagnostics/SourcePositionDTO.java
@@ -5,10 +5,10 @@ import spoon.reflect.cu.SourcePosition;
 /**
  * DTO for serializing Spoon SourcePosition to JSON
  */
-public record PositionDTO(String file, int line, int column) {
+public record SourcePositionDTO(String file, int line, int column) {
 
-    public static PositionDTO from(SourcePosition position) {
+    public static SourcePositionDTO from(SourcePosition position) {
         String file = position.getFile() != null ? position.getFile().getAbsolutePath() : "";
-        return new PositionDTO(file, position.getLine(), position.getColumn());
+        return new SourcePositionDTO(file, position.getLine() - 1, position.getColumn() - 1);
     }
 }

--- a/server/src/main/java/utils/ContextHistoryConverter.java
+++ b/server/src/main/java/utils/ContextHistoryConverter.java
@@ -11,6 +11,7 @@ import dtos.context.ContextHistoryDTO;
 import dtos.context.GhostDTO;
 import dtos.context.VariableDTO;
 import liquidjava.processor.context.ContextHistory;
+import liquidjava.processor.context.GhostState;
 import liquidjava.processor.context.RefinedVariable;
 
 /**
@@ -28,7 +29,7 @@ public class ContextHistoryConverter {
             toVariablesMap(contextHistory.getVars()),
             contextHistory.getInstanceVars().stream().map(VariableDTO::from).collect(Collectors.toList()),
             contextHistory.getGlobalVars().stream().map(VariableDTO::from).collect(Collectors.toList()),
-            contextHistory.getGhosts().stream().map(GhostDTO::from).collect(Collectors.toList()),
+            toGhostsMap(contextHistory.getGhosts()),
             contextHistory.getAliases().stream().map(AliasDTO::from).collect(Collectors.toList())
         );
     }
@@ -42,6 +43,15 @@ public class ContextHistoryConverter {
                 (left, right) -> left,
                 HashMap::new
             )),
+            (left, right) -> left,
+            HashMap::new
+        ));
+    }
+
+    private static Map<String, List<GhostDTO>> toGhostsMap(Map<String, Set<GhostState>> ghosts) {
+        return ghosts.entrySet().stream().collect(Collectors.toMap(
+            Map.Entry::getKey,
+            entry -> entry.getValue().stream().map(GhostDTO::from).collect(Collectors.toList()),
             (left, right) -> left,
             HashMap::new
         ));

--- a/server/src/main/java/utils/ContextHistoryConverter.java
+++ b/server/src/main/java/utils/ContextHistoryConverter.java
@@ -25,7 +25,7 @@ public class ContextHistoryConverter {
      */
     public static ContextHistoryDTO convertToDTO(ContextHistory contextHistory) {
         return new ContextHistoryDTO(
-            toVariablesMap(contextHistory.getFileScopeVars()),
+            toVariablesMap(contextHistory.getVars()),
             contextHistory.getInstanceVars().stream().map(VariableDTO::from).collect(Collectors.toList()),
             contextHistory.getGlobalVars().stream().map(VariableDTO::from).collect(Collectors.toList()),
             contextHistory.getGhosts().stream().map(GhostDTO::from).collect(Collectors.toList()),

--- a/server/src/main/java/utils/ContextHistoryConverter.java
+++ b/server/src/main/java/utils/ContextHistoryConverter.java
@@ -26,7 +26,7 @@ public class ContextHistoryConverter {
      */
     public static ContextHistoryDTO convertToDTO(ContextHistory contextHistory) {
         return new ContextHistoryDTO(
-            toVariablesMap(contextHistory.getVars()),
+            toVariablesMap(contextHistory.getFileScopeVars()),
             contextHistory.getInstanceVars().stream().map(VariableDTO::from).collect(Collectors.toList()),
             contextHistory.getGlobalVars().stream().map(VariableDTO::from).collect(Collectors.toList()),
             toGhostsMap(contextHistory.getGhosts()),


### PR DESCRIPTION
This PR improves the autocomplete suggestions by:
- [x] Not suggesting ghosts/states from different classes (aliases are fine)
- [x] Implementing annotation-specific suggestions
- [x] Implementing trigger characters (`"` and `.`)
- [x] Suggesting ghosts/states after `this.` or `old(this).`
- [x] Suggesting parameters in method and parameter level refinements 
- [x] Suggesting the variable we are refining (doesn't work very reliably because of the last point mentioned in the future work section)

### Future Work
- Not suggest `return` unless we are in a method level refinement (still shows for field refinements)
- Autocomplete for `@ExternalRefinementsFor` (similarly to the autocomplete VS Code provides in imports) 
- Have autocomplete work even in the presence of LiquidJava errors (e.g., when an error occurs, subsequent variables are not added to the context and therefore are not suggested)