### PR TITLE
DFA Dynamic Theme

### DIFF
--- a/client/src/webview/styles.ts
+++ b/client/src/webview/styles.ts
@@ -440,5 +440,44 @@ export function getStyles(): string {
         .mermaid .statediagramTitleText {
             font-size: 30px!important;
         }
+        .diagram-container .mermaid svg,
+        .diagram-container .mermaid svg * {
+            color: var(--vscode-foreground) !important;
+        }
+        .diagram-container .mermaid svg text,
+        .diagram-container .mermaid svg tspan,
+        .diagram-container .mermaid svg .label,
+        .diagram-container .mermaid svg .label text,
+        .diagram-container .mermaid svg .edgeLabel text {
+            fill: var(--vscode-foreground) !important;
+        }
+        .diagram-container .mermaid svg .edgeLabel rect,
+        .diagram-container .mermaid svg .labelBkg {
+            fill: var(--vscode-editor-background) !important;
+            stroke: var(--vscode-panel-border) !important;
+        }
+        .diagram-container .mermaid .edgeLabel,
+        .diagram-container .mermaid .edgeLabel *,
+        .diagram-container .mermaid .edgeLabel p,
+        .diagram-container .mermaid .edgeLabel span,
+        .diagram-container .mermaid .edgeLabel div {
+            color: var(--vscode-foreground) !important;
+            background: var(--vscode-editor-background) !important;
+        }
+        .diagram-container .mermaid svg rect,
+        .diagram-container .mermaid svg circle,
+        .diagram-container .mermaid svg ellipse,
+        .diagram-container .mermaid svg polygon {
+            fill: var(--vscode-editor-background) !important;
+            stroke: var(--vscode-foreground) !important;
+        }
+        .diagram-container .mermaid svg path,
+        .diagram-container .mermaid svg line {
+            stroke: var(--vscode-foreground) !important;
+        }
+        .diagram-container .mermaid svg marker path {
+            fill: var(--vscode-foreground) !important;
+            stroke: var(--vscode-foreground) !important;
+        }
     `;
 }


### PR DESCRIPTION
Closes #57. Dynamically updates the state machine diagram theme across VS Code light and dark themes.

### Dark Theme

<img width="566" height="630" alt="image" src="https://github.com/user-attachments/assets/6061660d-1601-494d-a015-08768533803d" />

### Light Theme

<img width="580" height="627" alt="image" src="https://github.com/user-attachments/assets/40660f24-359d-4e60-a09e-24209fb9791b" />
