### PR TITLE
Fix Independent Derivation Expansion

### DIFF
--- a/client/src/webview/views/diagnostics/derivation-nodes.ts
+++ b/client/src/webview/views/diagnostics/derivation-nodes.ts
@@ -77,8 +77,8 @@ function renderJsonTree(
     return `<span class="node-value">${JSON.stringify(node)}</span>`;
 }
 
-function hashError(error: LJError): string {
-    const content = `${error.title}|${error.message}|${error.file}|${error.position?.lineStart ?? 0}`;
+function hashError(error: LJError, scope: string): string {
+    const content = `${error.title}|${error.message}|${error.file}|${error.position?.lineStart ?? 0}|${scope}`;
     let hash = 0;
     for (let i = 0; i < content.length; i++) {
         const char = content.charCodeAt(i);
@@ -114,10 +114,14 @@ export function handleDerivationResetClick(target?: any): boolean {
     return false;
 }
 
-export function renderDerivationNode(error: RefinementError, node: ValDerivationNode): string {
+export function renderDerivationNode(
+    error: RefinementError,
+    node: ValDerivationNode,
+    scope: "expected" | "found"
+): string {
     if (!node.origin) return `<pre>${node.value}</pre>`; // no derivation available
     
-    const errorId = hashError(error);
+    const errorId = hashError(error, scope);
     const expansions = getExpansions(errorId);
     return /*html*/ `
         <div class="container derivation-container" data-error-id="${errorId}">

--- a/client/src/webview/views/diagnostics/errors.ts
+++ b/client/src/webview/views/diagnostics/errors.ts
@@ -31,8 +31,8 @@ export function renderErrors(errors: LJError[], expandedErrors: Set<number>): st
 const errorContentRenderers: Partial<Record<LJError['type'], (error: LJError) => string>> = {
     'refinement-error': (e: RefinementError) => /*html*/`
         ${e.customMessage ? renderSection('Message', e.customMessage) : ''}
-        ${renderCustomSection('Expected', renderDerivationNode(e, e.expected))}
-        ${renderCustomSection('Found', renderDerivationNode(e, e.found))}
+        ${renderCustomSection('Expected', renderDerivationNode(e, e.expected, 'expected'))}
+        ${renderCustomSection('Found', renderDerivationNode(e, e.found, 'found'))}
         ${e.counterexample ? renderSection('Counterexample', e.counterexample) : ''}
     `,
     'state-refinement-error': (e: StateRefinementError) => /*html*/`


### PR DESCRIPTION
This PR fixes a small issue where the expected and found derivation trees in the diagnostics webview shared the same expansion state, causing one section to expand or reset when interacting with the other. It scopes each tree independently so both can be expanded and reset without affecting each other.