### PR TITLE
Fix Variable Names

### DIFF
--- a/client/src/services/context.ts
+++ b/client/src/services/context.ts
@@ -86,7 +86,7 @@ function isBeforeOrEqual(line1: number, col1: number, line2: number, col2: numbe
 }
 
 export function filterInstanceVariables(variables: LJVariable[]): LJVariable[] {
-    return variables.filter(v => !v.name.includes("#"));
+    return variables.filter(v => !v.internalName.includes("#"));
 }
 
 export function filterDuplicateVariables(variables: LJVariable[]): LJVariable[] {
@@ -102,20 +102,20 @@ export function filterDuplicateVariables(variables: LJVariable[]): LJVariable[] 
 // Sorts variables by their position or name
 function sortVariables(variables: LJVariable[]): LJVariable[] {
     return variables.sort((left, right) => {
-        if (!left.position && !right.position) return compareVariableNames(left, right);
+        if (!left.position && !right.position) return compareVariableNames(left.internalName, right.internalName);
         if (!left.position) return 1;
         if (!right.position) return -1;
         if (left.position.lineStart !== right.position.lineStart) return left.position.lineStart - right.position.lineStart;
         if (left.position.colStart !== right.position.colStart) return right.position.colStart - left.position.colStart;
-        return compareVariableNames(left, right);
+        return compareVariableNames(left.internalName, right.internalName);
     });
 }
 
-function compareVariableNames(a: LJVariable, b: LJVariable): number {
-    if (a.name.startsWith("#") && b.name.startsWith("#")) return getOriginalVariableName(a.name).localeCompare(getOriginalVariableName(b.name));
-    if (a.name.startsWith("#")) return 1;
-    if (b.name.startsWith("#")) return -1;
-    return a.name.localeCompare(b.name);
+function compareVariableNames(a: string, b: string): number {
+    if (a.startsWith("#") && b.startsWith("#")) return getOriginalVariableName(a).localeCompare(getOriginalVariableName(b));
+    if (a.startsWith("#")) return 1;
+    if (b.startsWith("#")) return -1;
+    return a.localeCompare(b);
 }
 
 function normalizeVariableRefinements(variables: LJVariable[]): LJVariable[] {

--- a/client/src/types/context.ts
+++ b/client/src/types/context.ts
@@ -4,6 +4,7 @@ import { SourcePosition } from "./diagnostics";
 
 export type LJVariable = {
   name: string;
+  internalName: string;
   type: string;
   refinement: string;
   mainRefinement: string;

--- a/server/src/main/java/dtos/context/VariableDTO.java
+++ b/server/src/main/java/dtos/context/VariableDTO.java
@@ -10,6 +10,7 @@ import liquidjava.utils.VariableFormatter;
  */
 public record VariableDTO(
     String name,
+    String internalName,
     String type,
     String refinement,
     String mainRefinement,
@@ -21,6 +22,7 @@ public record VariableDTO(
         if (placement == null) return null;
         return new VariableDTO(
             VariableFormatter.formatVariable(refinedVariable.getName()),
+            refinedVariable.getName(),
             ContextHistoryDTO.stringifyType(refinedVariable.getType()),
             VariableFormatter.formatText(refinedVariable.getRefinement().toString()),
             VariableFormatter.formatText(refinedVariable.getMainRefinement().toString()),


### PR DESCRIPTION
This PR fixes a variable naming issue. After introducing superscript notation for instance variables, the code still expected the old `%x_n` format to get the original variable names and compare variable names. This broke autocomplete (suggesting instance variables) and caused incorrect sorting in the context debugger.

<img width="579" height="94" alt="image" src="https://github.com/user-attachments/assets/08eb03ef-8128-4c67-8198-44ef945645ab" />

Fixed this by sending both the pretty and internal variable names to the client. 