### PR TITLE
Methods Hover

### DIFF
--- a/client/src/services/context.ts
+++ b/client/src/services/context.ts
@@ -5,6 +5,7 @@ import { getOriginalVariableName } from "../utils/utils";
 
 export function handleContext(context: LJContext) {
     extension.context = context;
+    extension.logger?.client.info(JSON.stringify(context.methods, null, 2))
     if (!extension.file || !extension.currentSelection) return;
 
     // update variables based on new context in current selection

--- a/client/src/services/definition.ts
+++ b/client/src/services/definition.ts
@@ -1,0 +1,47 @@
+import * as vscode from 'vscode';
+import type { SourcePosition } from '../types/diagnostics';
+import { normalizeFilePath } from '../utils/utils';
+
+type Definition = {
+    uri: vscode.Uri;
+    range: vscode.Range;
+}
+
+export async function getDefinitions(document: vscode.TextDocument, position: vscode.Position): Promise<Definition[]> {
+    try {
+        const definitions = await vscode.commands.executeCommand<(vscode.Location | vscode.LocationLink)[]>(
+            'vscode.executeDefinitionProvider',
+            document.uri,
+            position
+        ) || [];
+        return definitions.map(definition => definition instanceof vscode.Location
+            ? { uri: definition.uri, range: definition.range }
+            : { uri: definition.targetUri, range: definition.targetSelectionRange || definition.targetRange }
+        );
+    } catch {
+        return [];
+    }
+}
+
+export function sourcePositionContains(position: SourcePosition, range: vscode.Range): boolean {
+    return toVSCodeRange(position).contains(range);
+}
+
+export function definitionMatchesPosition(definition: Definition, position: SourcePosition | null): boolean {
+    return !!position?.file &&
+        normalizeFilePath(definition.uri.fsPath) === position.file &&
+        rangesOverlap(definition.range, toVSCodeRange(position));
+}
+
+export function definitionMatchesClass(definition: Definition, targetClass: string): boolean {
+    const uri = definition.uri.toString();
+    return !!targetClass && (uri.includes(targetClass) || uri.includes(targetClass.replace(/\./g, '/')));
+}
+
+function rangesOverlap(left: vscode.Range, right: vscode.Range): boolean {
+    return left.contains(right.start) || left.contains(right.end) || right.contains(left.start) || right.contains(left.end);
+}
+
+function toVSCodeRange(range: SourcePosition): vscode.Range {
+    return new vscode.Range(range.lineStart, range.colStart, range.lineEnd, range.colEnd);
+}

--- a/client/src/services/definition.ts
+++ b/client/src/services/definition.ts
@@ -1,10 +1,7 @@
 import * as vscode from 'vscode';
-import type { SourcePosition } from '../types/diagnostics';
-import { normalizeFilePath } from '../utils/utils';
 
 type Definition = {
     uri: vscode.Uri;
-    range: vscode.Range;
 }
 
 export async function getDefinitions(document: vscode.TextDocument, position: vscode.Position): Promise<Definition[]> {
@@ -15,33 +12,15 @@ export async function getDefinitions(document: vscode.TextDocument, position: vs
             position
         ) || [];
         return definitions.map(definition => definition instanceof vscode.Location
-            ? { uri: definition.uri, range: definition.range }
-            : { uri: definition.targetUri, range: definition.targetSelectionRange || definition.targetRange }
+            ? { uri: definition.uri }
+            : { uri: definition.targetUri }
         );
     } catch {
         return [];
     }
 }
 
-export function sourcePositionContains(position: SourcePosition, range: vscode.Range): boolean {
-    return toVSCodeRange(position).contains(range);
-}
-
-export function definitionMatchesPosition(definition: Definition, position: SourcePosition | null): boolean {
-    return !!position?.file &&
-        normalizeFilePath(definition.uri.fsPath) === position.file &&
-        rangesOverlap(definition.range, toVSCodeRange(position));
-}
-
 export function definitionMatchesClass(definition: Definition, targetClass: string): boolean {
     const uri = definition.uri.toString();
     return !!targetClass && (uri.includes(targetClass) || uri.includes(targetClass.replace(/\./g, '/')));
-}
-
-function rangesOverlap(left: vscode.Range, right: vscode.Range): boolean {
-    return left.contains(right.start) || left.contains(right.end) || right.contains(left.start) || right.contains(left.end);
-}
-
-function toVSCodeRange(range: SourcePosition): vscode.Range {
-    return new vscode.Range(range.lineStart, range.colStart, range.lineEnd, range.colEnd);
 }

--- a/client/src/services/hover.ts
+++ b/client/src/services/hover.ts
@@ -99,7 +99,7 @@ function formatRefinement(refinement: string): string {
 }
 
 function formatStateRefinement(from: string | null, to: string | null): string {
-    return `@StateRefinement("${[from && `from=${from}`, to && `to=${to}`].filter(Boolean).join(', ')}")`;
+    return `@StateRefinement(${[from && `from="${from}"`, to && `to="${to}"`].filter(Boolean).join(', ')})`;
 }
 
 function formatMethodHover(method: LJMethod): string {

--- a/client/src/services/hover.ts
+++ b/client/src/services/hover.ts
@@ -3,7 +3,7 @@ import { extension } from '../state';
 import type { LJMethod, LJVariable } from '../types/context';
 import { getSelectionContextVariables } from './context';
 import { getOriginalVariableName, normalizeFilePath } from '../utils/utils';
-import { definitionMatchesClass, definitionMatchesPosition, getDefinitions, sourcePositionContains } from './definition';
+import { definitionMatchesClass, getDefinitions } from './definition';
 
 /**
  * Initializes hover provider for LiquidJava diagnostics
@@ -16,7 +16,7 @@ export function registerHover() {
 
             const variable = getHoveredVariable(document, position);
             if (variable && variable.mainRefinement && variable.mainRefinement !== 'true')
-                hoverContent.appendCodeblock(formatVariableHover(variable), 'java');
+                hoverContent.appendCodeblock(formatRefinement(variable.mainRefinement), 'java');
             else {
                 const method = await getHoveredMethod(document, position);
                 if (method) hoverContent.appendCodeblock(formatMethodHover(method), 'java');
@@ -63,14 +63,9 @@ async function getHoveredMethod(document: vscode.TextDocument, position: vscode.
     const hoveredWord = document.getText(wordRange);
     const file = normalizeFilePath(document.uri.fsPath);
     const methods = extension.context.methods.filter(method => methodNameMatches(method, hoveredWord));
-    const declaredMethod = methods.find(method => method.position?.file === file && sourcePositionContains(method.position, wordRange));
-    if (declaredMethod) return declaredMethod;
 
     const definitions = await getDefinitions(document, position);
-    const resolvedMethod = methods.find(method => definitions.some(definition =>
-        definitionMatchesPosition(definition, method.position) ||
-        definitionMatchesClass(definition, method.targetClass)
-    ));
+    const resolvedMethod = methods.find(method => definitions.some(definition => definitionMatchesClass(definition, method.targetClass)));
     if (resolvedMethod) return resolvedMethod;
 
     const receiver = document.lineAt(wordRange.start.line).text
@@ -99,18 +94,22 @@ function isBefore(range: { lineStart: number; colStart: number }, position: vsco
     return range.lineStart < position.line || range.lineStart === position.line && range.colStart < position.character;
 }
 
-function formatVariableHover(variable: LJVariable): string {
-    return `@Refinement("${variable.mainRefinement}")`;
+function formatRefinement(refinement: string): string {
+    return `@Refinement("${refinement}")`;
+}
+
+function formatStateRefinement(from: string | null, to: string | null): string {
+    return `@StateRefinement("${[from && `from=${from}`, to && `to=${to}`].filter(Boolean).join(', ')}")`;
 }
 
 function formatMethodHover(method: LJMethod): string {
     return [
-        method.returnRefinement && method.returnRefinement !== 'true' && `@Refinement("${method.returnRefinement}")`,
+        method.returnRefinement && method.returnRefinement !== 'true' && formatRefinement(method.returnRefinement),
         ...method.parameters
             .filter(p => p.mainRefinement && p.mainRefinement !== 'true')
-            .map(p => `${p.type} ${p.name} @Refinement("${p.mainRefinement}")`),
+            .map(p => `${p.type} ${p.name} ${formatRefinement(p.mainRefinement)}`),
         ...method.stateRefinements
             .filter(s => s.from || s.to)
-            .map(s => `@StateRefinement("${[s.from && `from=${s.from}`, s.to && `to=${s.to}`].filter(Boolean).join(', ')}")`)
+            .map(s => formatStateRefinement(s.from, s.to))
     ].filter(Boolean).join('\n');
 }

--- a/client/src/services/hover.ts
+++ b/client/src/services/hover.ts
@@ -1,8 +1,8 @@
 import * as vscode from 'vscode';
 import { extension } from '../state';
-import type { Range, LJVariable } from '../types/context';
+import type { LJMethod, LJVariable } from '../types/context';
 import { getSelectionContextVariables } from './context';
-import { getOriginalVariableName, normalizeFilePath, toRange } from '../utils/utils';
+import { getOriginalVariableName, normalizeFilePath } from '../utils/utils';
 
 /**
  * Initializes hover provider for LiquidJava diagnostics
@@ -15,7 +15,11 @@ export function registerHover() {
 
             const variable = getHoveredVariable(document, position);
             if (variable && variable.mainRefinement && variable.mainRefinement !== 'true')
-                hoverContent.appendCodeblock(`@Refinement("${variable.mainRefinement}")`, 'java');
+                hoverContent.appendCodeblock(formatVariableHover(variable), 'java');
+            else {
+                const method = getHoveredMethod(document, position);
+                if (method) hoverContent.appendCodeblock(formatMethodHover(method), 'java');
+            }
 
             const diagnostics = vscode.languages.getDiagnostics(document.uri);
             const containsDiagnostic = !!diagnostics.find(d => d.range.contains(position) && d.source === 'liquidjava');
@@ -47,4 +51,34 @@ function getHoveredVariable(document: vscode.TextDocument, position: vscode.Posi
     };
     const { allVars } = getSelectionContextVariables(file, positionAfterVariable);
     return allVars.find(variable => getOriginalVariableName(variable.name) === hoveredWord);
+}
+
+function getHoveredMethod(document: vscode.TextDocument, position: vscode.Position): LJMethod | null {
+    if (!extension.context) return null;
+
+    const wordRange = document.getWordRangeAtPosition(position, /[A-Za-z_][A-Za-z0-9_]*/);
+    if (!wordRange) return null;
+
+    const hoveredWord = document.getText(wordRange);
+    const file = normalizeFilePath(document.uri.fsPath);
+    return extension.context.methods.find(method => method.name === hoveredWord && (!method.position?.file || method.position.file === file))
+        || extension.context.methods.find(method => method.name === hoveredWord)
+        || null;
+}
+
+function formatVariableHover(variable: LJVariable): string {
+    return `@Refinement("${variable.mainRefinement}")`;
+}
+
+function formatMethodHover(method: LJMethod): string {
+    return [
+        method.signature,
+        method.returnRefinement && method.returnRefinement !== 'true' && `@Refinement("${method.returnRefinement}")`,
+        ...method.parameters
+            .filter(p => p.mainRefinement && p.mainRefinement !== 'true')
+            .map(p => `${p.type} ${p.name} @Refinement("${p.mainRefinement}")`),
+        ...method.stateRefinements
+            .filter(s => s.from || s.to)
+            .map(s => `@StateRefinement("${s.from ? `from=${s.from}, ` : ""}` +`${s.to ? `to=${s.to}` : ""}`)
+    ].filter(Boolean).join('\n');
 }

--- a/client/src/services/hover.ts
+++ b/client/src/services/hover.ts
@@ -3,13 +3,14 @@ import { extension } from '../state';
 import type { LJMethod, LJVariable } from '../types/context';
 import { getSelectionContextVariables } from './context';
 import { getOriginalVariableName, normalizeFilePath } from '../utils/utils';
+import { definitionMatchesClass, definitionMatchesPosition, getDefinitions, sourcePositionContains } from './definition';
 
 /**
  * Initializes hover provider for LiquidJava diagnostics
  */
 export function registerHover() {
     vscode.languages.registerHoverProvider('java', {
-        provideHover(document, position) {
+        async provideHover(document, position) {
             const hoverContent = new vscode.MarkdownString();
             hoverContent.isTrusted = true;
 
@@ -17,7 +18,7 @@ export function registerHover() {
             if (variable && variable.mainRefinement && variable.mainRefinement !== 'true')
                 hoverContent.appendCodeblock(formatVariableHover(variable), 'java');
             else {
-                const method = getHoveredMethod(document, position);
+                const method = await getHoveredMethod(document, position);
                 if (method) hoverContent.appendCodeblock(formatMethodHover(method), 'java');
             }
 
@@ -53,7 +54,7 @@ function getHoveredVariable(document: vscode.TextDocument, position: vscode.Posi
     return allVars.find(variable => getOriginalVariableName(variable.name) === hoveredWord);
 }
 
-function getHoveredMethod(document: vscode.TextDocument, position: vscode.Position): LJMethod | null {
+async function getHoveredMethod(document: vscode.TextDocument, position: vscode.Position): Promise<LJMethod | null> {
     if (!extension.context) return null;
 
     const wordRange = document.getWordRangeAtPosition(position, /[A-Za-z_][A-Za-z0-9_]*/);
@@ -61,9 +62,41 @@ function getHoveredMethod(document: vscode.TextDocument, position: vscode.Positi
 
     const hoveredWord = document.getText(wordRange);
     const file = normalizeFilePath(document.uri.fsPath);
-    return extension.context.methods.find(method => method.name === hoveredWord && (!method.position?.file || method.position.file === file))
-        || extension.context.methods.find(method => method.name === hoveredWord)
-        || null;
+    const methods = extension.context.methods.filter(method => methodNameMatches(method, hoveredWord));
+    const declaredMethod = methods.find(method => method.position?.file === file && sourcePositionContains(method.position, wordRange));
+    if (declaredMethod) return declaredMethod;
+
+    const definitions = await getDefinitions(document, position);
+    const resolvedMethod = methods.find(method => definitions.some(definition =>
+        definitionMatchesPosition(definition, method.position) ||
+        definitionMatchesClass(definition, method.targetClass)
+    ));
+    if (resolvedMethod) return resolvedMethod;
+
+    const receiver = document.lineAt(wordRange.start.line).text
+        .slice(0, wordRange.start.character)
+        .match(/([A-Za-z_][A-Za-z0-9_]*)\s*\.\s*$/)?.[1];
+    if (!receiver) return null;
+    const receiverVariable = [...(extension.context?.globalVars || []), ...(extension.context?.localVars || [])]
+        .find(variable =>
+            getOriginalVariableName(variable.name) === receiver &&
+            (!variable.position || variable.position.file === file && isBefore(variable.position, wordRange.start))
+        );
+    if (!receiverVariable) return null;
+
+    return methods.find(method => typeMatchesTargetClass(receiverVariable.type, method.targetClass)) || null;
+}
+
+function methodNameMatches(method: LJMethod, hoveredWord: string): boolean {
+    return method.name === hoveredWord || method.name.endsWith(`.${hoveredWord}`);
+}
+
+function typeMatchesTargetClass(type: string, targetClass: string): boolean {
+    return type === targetClass || targetClass.endsWith(`.${type}`) || type.endsWith(`.${targetClass}`);
+}
+
+function isBefore(range: { lineStart: number; colStart: number }, position: vscode.Position): boolean {
+    return range.lineStart < position.line || range.lineStart === position.line && range.colStart < position.character;
 }
 
 function formatVariableHover(variable: LJVariable): string {
@@ -72,13 +105,12 @@ function formatVariableHover(variable: LJVariable): string {
 
 function formatMethodHover(method: LJMethod): string {
     return [
-        method.signature,
         method.returnRefinement && method.returnRefinement !== 'true' && `@Refinement("${method.returnRefinement}")`,
         ...method.parameters
             .filter(p => p.mainRefinement && p.mainRefinement !== 'true')
             .map(p => `${p.type} ${p.name} @Refinement("${p.mainRefinement}")`),
         ...method.stateRefinements
             .filter(s => s.from || s.to)
-            .map(s => `@StateRefinement("${s.from ? `from=${s.from}, ` : ""}` +`${s.to ? `to=${s.to}` : ""}`)
+            .map(s => `@StateRefinement("${[s.from && `from=${s.from}`, s.to && `to=${s.to}`].filter(Boolean).join(', ')}")`)
     ].filter(Boolean).join('\n');
 }

--- a/client/src/services/hover.ts
+++ b/client/src/services/hover.ts
@@ -107,7 +107,7 @@ function formatMethodHover(method: LJMethod): string {
         method.returnRefinement && method.returnRefinement !== 'true' && formatRefinement(method.returnRefinement),
         ...method.parameters
             .filter(p => p.mainRefinement && p.mainRefinement !== 'true')
-            .map(p => `${p.type} ${p.name} ${formatRefinement(p.mainRefinement)}`),
+            .map(p => `${formatRefinement(p.mainRefinement)} ${p.type} ${p.name}`),
         ...method.stateRefinements
             .filter(s => s.from || s.to)
             .map(s => formatStateRefinement(s.from, s.to))

--- a/client/src/types/context.ts
+++ b/client/src/types/context.ts
@@ -40,7 +40,6 @@ export type LJMethod = {
   returnRefinement: string;
   parameters: LJVariable[];
   stateRefinements: LJMethodStateRefinement[];
-  position: SourcePosition | null;
 }
 
 export type LJContext = {

--- a/client/src/types/context.ts
+++ b/client/src/types/context.ts
@@ -29,11 +29,30 @@ export type LJAlias = {
   predicate: string;
 }
 
+export type LJMethodStateRefinement = {
+  from: string | null;
+  to: string | null;
+  message: string | null;
+}
+
+export type LJMethod = {
+  name: string;
+  signature: string;
+  targetClass: string;
+  returnType: string;
+  returnRefinement: string;
+  parameters: LJVariable[];
+  stateRefinements: LJMethodStateRefinement[];
+  position: SourcePosition | null;
+  annotationPosition: SourcePosition | null;
+}
+
 export type LJContext = {
   localVars: LJVariable[];
   globalVars: LJVariable[];
   ghosts: LJGhost[];
   aliases: LJAlias[];
+  methods: LJMethod[];
   visibleVars: LJVariable[]; // variables visible in the current selection
   allVars: LJVariable[]; // instance vars + global vars + vars in scope
   fileScopes: Record<string, Range[]>; // file -> scopes

--- a/client/src/types/context.ts
+++ b/client/src/types/context.ts
@@ -32,19 +32,15 @@ export type LJAlias = {
 export type LJMethodStateRefinement = {
   from: string | null;
   to: string | null;
-  message: string | null;
 }
 
 export type LJMethod = {
   name: string;
-  signature: string;
   targetClass: string;
-  returnType: string;
   returnRefinement: string;
   parameters: LJVariable[];
   stateRefinements: LJMethodStateRefinement[];
   position: SourcePosition | null;
-  annotationPosition: SourcePosition | null;
 }
 
 export type LJContext = {

--- a/server/src/main/java/dtos/context/ContextHistoryDTO.java
+++ b/server/src/main/java/dtos/context/ContextHistoryDTO.java
@@ -14,6 +14,7 @@ public record ContextHistoryDTO(
     List<VariableDTO> globalVars,
     List<GhostDTO> ghosts,
     List<AliasDTO> aliases,
+    List<MethodDTO> methods,
     Map<String, List<SourcePositionDTO>> fileScopes
 ) {
     public static String stringifyType(CtTypeReference<?> typeReference) {

--- a/server/src/main/java/dtos/context/MethodDTO.java
+++ b/server/src/main/java/dtos/context/MethodDTO.java
@@ -15,37 +15,30 @@ import liquidjava.rj_language.ast.formatter.ExpressionFormatter;
  */
 public record MethodDTO(
     String name,
-    String signature,
     String targetClass,
-    String returnType,
     String returnRefinement,
     List<VariableDTO> parameters,
     List<StateRefinementDTO> stateRefinements,
-    SourcePositionDTO position,
-    SourcePositionDTO annotationPosition
+    SourcePositionDTO position
 ) {
     public static MethodDTO from(RefinedFunction refinedFunction) {
         PlacementInCode placement = refinedFunction.getPlacementInCode();
         if (placement == null) return null;
         return new MethodDTO(
             refinedFunction.getName(),
-            refinedFunction.getSignature(),
             refinedFunction.getTargetClass(),
-            ContextHistoryDTO.stringifyType(refinedFunction.getType()),
             format(refinedFunction.getRefReturn()),
             refinedFunction.getArguments().stream().map(VariableDTO::from).filter(v -> v != null).collect(Collectors.toList()),
             refinedFunction.getAllStates().stream().map(StateRefinementDTO::from).collect(Collectors.toList()),
-            SourcePositionDTO.from(placement.getPosition()),
-            SourcePositionDTO.from(placement.getAnnotationPosition())
+            SourcePositionDTO.from(placement.getPosition())
         );
     }
 
-    public record StateRefinementDTO(String from, String to, String message) {
+    public record StateRefinementDTO(String from, String to) {
         public static StateRefinementDTO from(ObjectState state) {
             return new StateRefinementDTO(
                 state.hasFrom() ? format(state.getFrom()) : null,
-                state.hasTo() ? format(state.getTo()) : null,
-                state.getMessage()
+                state.hasTo() ? format(state.getTo()) : null
             );
         }
     }

--- a/server/src/main/java/dtos/context/MethodDTO.java
+++ b/server/src/main/java/dtos/context/MethodDTO.java
@@ -3,9 +3,7 @@ package dtos.context;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import dtos.diagnostics.SourcePositionDTO;
 import liquidjava.processor.context.ObjectState;
-import liquidjava.processor.context.PlacementInCode;
 import liquidjava.processor.context.RefinedFunction;
 import liquidjava.rj_language.Predicate;
 import liquidjava.rj_language.ast.formatter.ExpressionFormatter;
@@ -18,19 +16,15 @@ public record MethodDTO(
     String targetClass,
     String returnRefinement,
     List<VariableDTO> parameters,
-    List<StateRefinementDTO> stateRefinements,
-    SourcePositionDTO position
+    List<StateRefinementDTO> stateRefinements
 ) {
     public static MethodDTO from(RefinedFunction refinedFunction) {
-        PlacementInCode placement = refinedFunction.getPlacementInCode();
-        if (placement == null) return null;
         return new MethodDTO(
             refinedFunction.getName(),
             refinedFunction.getTargetClass(),
             format(refinedFunction.getRefReturn()),
             refinedFunction.getArguments().stream().map(VariableDTO::from).filter(v -> v != null).collect(Collectors.toList()),
-            refinedFunction.getAllStates().stream().map(StateRefinementDTO::from).collect(Collectors.toList()),
-            SourcePositionDTO.from(placement.getPosition())
+            refinedFunction.getAllStates().stream().map(StateRefinementDTO::from).collect(Collectors.toList())
         );
     }
 

--- a/server/src/main/java/dtos/context/MethodDTO.java
+++ b/server/src/main/java/dtos/context/MethodDTO.java
@@ -1,0 +1,56 @@
+package dtos.context;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import dtos.diagnostics.SourcePositionDTO;
+import liquidjava.processor.context.ObjectState;
+import liquidjava.processor.context.PlacementInCode;
+import liquidjava.processor.context.RefinedFunction;
+import liquidjava.rj_language.Predicate;
+import liquidjava.rj_language.ast.formatter.ExpressionFormatter;
+
+/**
+ * DTO for serializing RefinedFunction instances to JSON.
+ */
+public record MethodDTO(
+    String name,
+    String signature,
+    String targetClass,
+    String returnType,
+    String returnRefinement,
+    List<VariableDTO> parameters,
+    List<StateRefinementDTO> stateRefinements,
+    SourcePositionDTO position,
+    SourcePositionDTO annotationPosition
+) {
+    public static MethodDTO from(RefinedFunction refinedFunction) {
+        PlacementInCode placement = refinedFunction.getPlacementInCode();
+        if (placement == null) return null;
+        return new MethodDTO(
+            refinedFunction.getName(),
+            refinedFunction.getSignature(),
+            refinedFunction.getTargetClass(),
+            ContextHistoryDTO.stringifyType(refinedFunction.getType()),
+            format(refinedFunction.getRefReturn()),
+            refinedFunction.getArguments().stream().map(VariableDTO::from).filter(v -> v != null).collect(Collectors.toList()),
+            refinedFunction.getAllStates().stream().map(StateRefinementDTO::from).collect(Collectors.toList()),
+            SourcePositionDTO.from(placement.getPosition()),
+            SourcePositionDTO.from(placement.getAnnotationPosition())
+        );
+    }
+
+    public record StateRefinementDTO(String from, String to, String message) {
+        public static StateRefinementDTO from(ObjectState state) {
+            return new StateRefinementDTO(
+                state.hasFrom() ? format(state.getFrom()) : null,
+                state.hasTo() ? format(state.getTo()) : null,
+                state.getMessage()
+            );
+        }
+    }
+
+    private static String format(Predicate predicate) {
+        return predicate == null ? "" : ExpressionFormatter.format(predicate);
+    }
+}

--- a/server/src/main/java/dtos/diagnostics/SourcePositionDTO.java
+++ b/server/src/main/java/dtos/diagnostics/SourcePositionDTO.java
@@ -9,8 +9,12 @@ public record SourcePositionDTO(String file, int lineStart, int colStart, int li
 
     public static SourcePositionDTO from(SourcePosition pos) {
         if (pos == null) return null;
-        String file = pos.getFile() != null ? pos.getFile().getAbsolutePath() : null;
-        return new SourcePositionDTO(file, pos.getLine() - 1, pos.getColumn() - 1, pos.getEndLine() - 1, pos.getEndColumn());
+        try {
+            String file = pos.getFile() != null ? pos.getFile().getAbsolutePath() : null;
+            return new SourcePositionDTO(file, pos.getLine() - 1, pos.getColumn() - 1, pos.getEndLine() - 1, pos.getEndColumn());
+        } catch (UnsupportedOperationException e) {
+            return null;
+        }
     }
 
     public static SourcePositionDTO from(String pos) {

--- a/server/src/main/java/utils/ContextHistoryConverter.java
+++ b/server/src/main/java/utils/ContextHistoryConverter.java
@@ -8,6 +8,7 @@ import java.util.stream.Collectors;
 
 import dtos.context.AliasDTO;
 import dtos.context.ContextHistoryDTO;
+import dtos.context.MethodDTO;
 import dtos.context.GhostDTO;
 import dtos.context.VariableDTO;
 import dtos.diagnostics.SourcePositionDTO;
@@ -29,6 +30,7 @@ public class ContextHistoryConverter {
             contextHistory.getGlobalVars().stream().map(VariableDTO::from).filter(v -> v != null).collect(Collectors.toList()),
             contextHistory.getGhosts().stream().map(GhostDTO::from).collect(Collectors.toList()),
             contextHistory.getAliases().stream().map(AliasDTO::from).collect(Collectors.toList()),
+            contextHistory.getMethods().stream().map(MethodDTO::from).filter(f -> f != null).collect(Collectors.toList()),
             parseFileScopes(contextHistory.getFileScopes())
         );
     }


### PR DESCRIPTION
Closes #72. Adds hover for methods using the updated context history from [#218](https://github.com/liquid-java/liquidjava/pull/218). It displays return, parameter, and state refinements. Since multiple classes can have methods with the same name, it uses VS Code definition resolution and filters methods by the receiver type.

### Examples

<img width="745" height="275" alt="image" src="https://github.com/user-attachments/assets/286f4ed3-8f72-4e73-b516-09ee36fc2cf0" />

<img width="874" height="199" alt="image" src="https://github.com/user-attachments/assets/9b450dbb-fa28-443a-a4a4-3be2f5859527" />
