### PR TITLE
Fix Context Debugger Startup

### DIFF
--- a/client/src/services/context.ts
+++ b/client/src/services/context.ts
@@ -1,6 +1,6 @@
 import { extension } from "../state";
 import { LJContext, Range, LJVariable } from "../types/context";
-import { SourcePosition } from "../types/diagnostics";
+import { RefinementMismatchError, SourcePosition } from "../types/diagnostics";
 import { getOriginalVariableName } from "../utils/utils";
 
 export function handleContext(context: LJContext) {
@@ -11,6 +11,7 @@ export function handleContext(context: LJContext) {
     const { allVars, visibleVars } = getSelectionContextVariables(extension.file, extension.currentSelection);
     extension.context.visibleVars = visibleVars;
     extension.context.allVars = allVars;
+    updateErrorAtCursor();
     extension.webview.sendMessage({ type: "context", context: extension.context, errorAtCursor: extension.errorAtCursor });
 }
 
@@ -22,6 +23,22 @@ export function getSelectionContextVariables(file: string, selection: Range): { 
     const visibleVarsByAnnotationPosition = getVisibleVariables(variablesInScope, file, selection, true);
     const allVars = sortVariables(normalizeVariableRefinements([...globalVars, ...visibleVarsByPosition]));
     return { visibleVars: visibleVarsByAnnotationPosition, allVars };
+}
+
+export function updateErrorAtCursor() {
+    if (!extension.file || !extension.currentSelection) return;
+    const errors: RefinementMismatchError[] = extension.diagnostics?.filter(d => d.type === 'refinement-error' || d.type === 'state-refinement-error') as RefinementMismatchError[] || [];
+    const scopes = extension.context?.fileScopes[extension.file] || [];
+    const errorAtCursor = errors.find(error => {
+        if (!error.position) return false;
+        const sameFile = error.position.file === extension.file;
+        const beforeCursor = isPositionBefore(error.position, extension.currentSelection);
+        if (!sameFile || !beforeCursor) return false;
+        // check if error is within a scope that contains the cursor
+        const errorScope = scopes.find(scope => isRangeWithin(error.position, scope));
+        return errorScope && isRangeWithin(extension.currentSelection, errorScope);
+    });
+    extension.errorAtCursor = errorAtCursor;
 }
 
 function getVariablesInScope(variables: LJVariable[], file: string, selection: Range): LJVariable[] {

--- a/client/src/services/diagnostics.ts
+++ b/client/src/services/diagnostics.ts
@@ -1,8 +1,8 @@
 import * as vscode from "vscode";
 import { extension } from "../state";
-import { LJDiagnostic, RefinementMismatchError } from "../types/diagnostics";
+import { LJDiagnostic } from "../types/diagnostics";
 import { StatusBarState, updateStatusBar } from "./status-bar";
-import { isPositionBefore, isRangeWithin } from "./context";
+import { updateErrorAtCursor } from "./context";
 
 /**
  * Handles LiquidJava diagnostics received from the language server
@@ -13,7 +13,10 @@ export function handleLJDiagnostics(diagnostics: LJDiagnostic[]) {
     const statusBarState: StatusBarState = containsError ? "failed" : "passed";
     updateStatusBar(statusBarState);
     extension.diagnostics = diagnostics;
+    updateErrorAtCursor();
     extension.webview?.sendMessage({ type: "diagnostics", diagnostics });
+    if (extension.context)
+        extension.webview?.sendMessage({ type: "context", context: extension.context, errorAtCursor: extension.errorAtCursor });
 }
 
 /**
@@ -36,20 +39,4 @@ export async function verify() {
     updateStatusBar("loading");
     
     extension.client.sendNotification("liquidjava/verify", { uri });
-}
-
-export function updateErrorAtCursor() {
-    if (!extension.file || !extension.currentSelection) return;
-    const errors: RefinementMismatchError[] = extension.diagnostics?.filter(d => d.type === 'refinement-error' || d.type === 'state-refinement-error') as RefinementMismatchError[] || [];
-    const scopes = extension.context?.fileScopes[extension.file] || [];
-    const errorAtCursor = errors.find(error => {
-        if (!error.position) return false;
-        const sameFile = error.position.file === extension.file;
-        const beforeCursor = isPositionBefore(error.position, extension.currentSelection);
-        if (!sameFile || !beforeCursor) return false;
-        // check if error is within a scope that contains the cursor
-        const errorScope = scopes.find(scope => isRangeWithin(error.position, scope));
-        return errorScope && isRangeWithin(extension.currentSelection, errorScope);
-    });
-    extension.errorAtCursor = errorAtCursor;
 }

--- a/client/src/services/events.ts
+++ b/client/src/services/events.ts
@@ -2,10 +2,8 @@ import * as vscode from 'vscode';
 import { extension } from '../state';
 import { updateStateMachine } from './state-machine';
 import { SELECTION_DEBOUNCE_MS } from '../utils/constants';
-import { getSelectionContextVariables, normalizeRange } from './context';
+import { getSelectionContextVariables, normalizeRange, updateErrorAtCursor } from './context';
 import { normalizeFilePath, toRange } from '../utils/utils';
-import { updateErrorAtCursor } from './diagnostics';
-import type { Range } from '../types/context';
 
 let selectionTimeout: NodeJS.Timeout | null = null;
 
@@ -60,11 +58,14 @@ export async function onSelectionChange(event: vscode.TextEditorSelectionChangeE
  * @param selection The new selection
  */
 function handleContextUpdate(selection: vscode.Selection) {
-    if (!extension.file || !extension.context) return;
-    
+    if (!extension.file) return;
+
     const normalizedRange = normalizeRange(toRange(selection));
-    const { allVars, visibleVars } = getSelectionContextVariables(extension.file, normalizedRange);
     extension.currentSelection = normalizedRange;
+
+    if (!extension.context) return;
+
+    const { allVars, visibleVars } = getSelectionContextVariables(extension.file, normalizedRange);
     extension.context.visibleVars = visibleVars;
     extension.context.allVars = allVars;
     updateErrorAtCursor();


### PR DESCRIPTION
This PR fixes the context debugger not showing on startup, which required the user to move the cursor after the initial verification was performed. Fixed this by saving the initial editor selection before the context arrives and using it when it is received.