### PR TITLE
Normalize Self-Referential Invocations

### DIFF
--- a/client/src/services/context.ts
+++ b/client/src/services/context.ts
@@ -128,6 +128,6 @@ function normalizeVariableRefinements(variables: LJVariable[]): LJVariable[] {
             return left !== right ? [v] : []; // filter tautologies like x == x
         }
         if (v.refinement.includes("!=") || v.refinement.includes(">") || v.refinement.includes("<")) return [v];
-        return [{ ...v, refinement: `${v.name} == ${v.refinement}` }];
+        return [{ ...v, refinement: `${v.name} == ${v.refinement.replace(`(${v.name})`, "()")}` }];
     });
 }


### PR DESCRIPTION
This PR fixes an issue in the context debugger where variable refinements could appear as confusing self-referential expressions, such as `a == ghost(a)`.
This happened because refinements without an explicit comparison are displayed by joining the variable name with its refinement using the format `var == refinement`.
A possible solution for this is replacing occurrences of `(var)` with `()`, so we display `a == ghost()` instead of `a == ghost(a)`.

> [!CAUTION]
> Not sure if this will break other cases, but parentheses are only added for function invocations and for more complex expressions that require them (after merging [#217](https://github.com/liquid-java/liquidjava/pull/217)).

### Example

#### Before

<img width="710" height="434" alt="image" src="https://github.com/user-attachments/assets/0f632105-1d52-4bb6-bef4-413708724d0a" />

#### After

<img width="711" height="435" alt="image" src="https://github.com/user-attachments/assets/8a91b0d4-8924-4d59-8e16-96bfb8cb6b49" />
