### PR TITLE
Update Context Debugger

### DIFF
--- a/client/src/services/context.ts
+++ b/client/src/services/context.ts
@@ -139,13 +139,12 @@ function compareVariableNames(a: string, b: string): number {
 }
 
 function normalizeVariableRefinements(variables: LJVariable[]): LJVariable[] {
-    return Array.from(new Map(variables.map(v => [v.refinement, v])).values()).flatMap(v => {
+    return Array.from(new Map(variables.map(v => [`${v.internalName}:${v.refinement}`, v])).values()).flatMap(v => { // remove duplicates
         if (!v.refinement || v.refinement === "true") return []; // filter out trivial refinements
         if (v.refinement.includes("==")) {
             const [left, right] = v.refinement.split("==").map(s => s.trim());
             return left !== right ? [v] : []; // filter tautologies like x == x
         }
-        if (v.refinement.includes("!=") || v.refinement.includes(">") || v.refinement.includes("<")) return [v];
-        return [{ ...v, refinement: `${v.name} == ${v.refinement}` }];
+        return [v];
     });
 }

--- a/client/src/webview/styles.ts
+++ b/client/src/webview/styles.ts
@@ -288,18 +288,40 @@ export function getStyles(): string {
             font-family: var(--vscode-editor-font-family);
             font-size: 0.9em;
         }
-        .context-section {
+        .context-section table {
+            width: 100%;
+            table-layout: fixed;
             margin-bottom: 1rem;
         }
+
+        .context-variables-table .context-variables-column {
+            width: 33.33%;
+        }
+
+        .context-variables-table .context-refinement-column {
+            width: 66.67%;
+        }
+
+        .context-variables-table th:first-child,
         .context-section table td:first-child {
             text-align: left;
-            flex: 1;
-            min-width: 0;
         }
+
+        .context-variables-table th:first-child {
+            padding-left: calc(0.75rem + 0.8rem);
+        }
+
+        .context-variables-table th:last-child,
         .context-section table td:last-child {
             text-align: right;
-            flex-shrink: 0;
-            white-space: nowrap;
+        }
+        .context-variables-table td.failing-refinement {
+            text-align: right;
+        }
+        .failing-refinement .highlight-var-btn {
+            display: flex;
+            justify-content: flex-end;
+            width: 100%;
         }
         .context-toggle-btn {
             display: flex;
@@ -349,34 +371,6 @@ export function getStyles(): string {
         }
         .highlight-var-btn.error:hover {
             background-color: #c92e26;
-        }
-        .failing-refinement {
-            position: relative;
-        }
-        .failing-refinement::after {
-            content: attr(data-tooltip);
-            position: absolute;
-            left: 0;
-            bottom: calc(100% + 0.35rem);
-            padding: 0.4rem 0.5rem;
-            border-radius: 4px;
-            background: var(--vscode-editorHoverWidget-background);
-            border: 1px solid var(--vscode-editorHoverWidget-border);
-            color: var(--vscode-editorHoverWidget-foreground);
-            font-size: 0.8rem;
-            line-height: 1.4;
-            white-space: nowrap;
-            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
-            opacity: 0;
-            visibility: hidden;
-            pointer-events: none;
-            transition: opacity 0.08s ease, visibility 0.08s ease;
-            transition-delay: 0.08s;
-            z-index: 10;
-        }
-        .failing-refinement:hover::after {
-            opacity: 1;
-            visibility: visible;
         }
         .diagram-section {
             margin-bottom: 1.5rem;

--- a/client/src/webview/styles.ts
+++ b/client/src/webview/styles.ts
@@ -313,14 +313,14 @@ export function getStyles(): string {
 
         .context-variables-table th:last-child,
         .context-section table td:last-child {
-            text-align: right;
+            text-align: left;
         }
         .context-variables-table td.failing-refinement {
-            text-align: right;
+            text-align: center;
         }
         .failing-refinement .highlight-var-btn {
             display: flex;
-            justify-content: flex-end;
+            justify-content: center;
             width: 100%;
         }
         .context-toggle-btn {

--- a/client/src/webview/views/context/variables.ts
+++ b/client/src/webview/views/context/variables.ts
@@ -16,7 +16,7 @@ export function renderContextVariables(variables: LJVariable[], isExpanded: bool
                         </colgroup>
                         <thead>
                             <tr>
-                                <th>Variable</th>
+                                <th>Name</th>
                                 <th>Refinement</th>
                             </tr>
                         </thead>

--- a/client/src/webview/views/context/variables.ts
+++ b/client/src/webview/views/context/variables.ts
@@ -1,7 +1,6 @@
 import { LJVariable } from "../../../types/context";
 import { RefinementMismatchError } from "../../../types/diagnostics";
-import { escapeHtml, getSimpleName } from "../../utils";
-import { renderLocationLink, renderToggleSection, renderHighlightButton } from "../sections";
+import { renderToggleSection, renderHighlightButton } from "../sections";
 
 export function renderContextVariables(variables: LJVariable[], isExpanded: boolean, errorAtCursor?: RefinementMismatchError): string {
     const expected  = errorAtCursor ? errorAtCursor.type == "refinement-error" ? errorAtCursor.expected.value : errorAtCursor.expected : undefined;
@@ -10,15 +9,27 @@ export function renderContextVariables(variables: LJVariable[], isExpanded: bool
             ${renderToggleSection('Variables', 'context-vars', isExpanded)}
             <div id="context-vars" class="context-section-content ${isExpanded ? '' : 'collapsed'}">
                 ${variables.length > 0 ? /*html*/`
-                    <table>
+                    <table class="context-variables-table">
+                        <colgroup>
+                            <col class="context-variables-column">
+                            <col class="context-refinement-column">
+                        </colgroup>
+                        <thead>
+                            <tr>
+                                <th>Variable</th>
+                                <th>Refinement</th>
+                            </tr>
+                        </thead>
                         <tbody>
                             ${variables.map(variable => /*html*/`
                                 <tr>
-                                    <td>${renderHighlightButton(variable.position, variable.refinement)}</td>
-                                    <td><code>${getSimpleName(variable.type)}</code></td>
+                                    <td>${renderHighlightButton(variable.position, variable.name)}</td>
+                                    <td><code>${variable.refinement}</code></td>
                                 </tr>
                             `).join('')}
-                            ${errorAtCursor ? /*html*/`<tr><td><code class="failing-refinement" data-tooltip="${escapeHtml(errorAtCursor.title)}">${renderHighlightButton(errorAtCursor.position, '⊢ ' + expected, true)}</code></td><td></td></tr>` : ''}
+                            ${errorAtCursor ? /*html*/`
+                                <tr><td class="failing-refinement" colspan="2">${renderHighlightButton(errorAtCursor.position, '⊢ ' + expected, true)}</td></tr>`
+                            : ''}
                         </tbody>
                     </table>
                 `: '<p>No variables declared at the cursor position</p>'}


### PR DESCRIPTION
This PR updates the context debugger view to split the variables and their refinements, which were displayed in a single columns and could be difficult to understand in some more complex cases.

### Example

#### Before

<img width="1740" height="816" alt="image" src="https://github.com/user-attachments/assets/97ea4bdc-a8a5-431e-8cd9-adde03307782" />

#### After

<img width="872" height="420" alt="image" src="https://github.com/user-attachments/assets/7fc95e87-6d96-47e3-8bc6-d8a92f9f9002" />
