### PR TITLE
Reveal Diagnostics from CodeLens

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -9,6 +9,7 @@ import { registerWebview } from "./services/webview";
 import { registerHover } from "./services/hover";
 import { registerEvents } from "./services/events";
 import { registerAutocomplete } from "./services/autocomplete";
+import { registerCodeLens } from "./services/codelens";
 import { runLanguageServer, stopLanguageServer } from "./lsp/server";
 import { runClient, stopClient } from "./lsp/client";
 
@@ -25,6 +26,7 @@ export async function activate(context: vscode.ExtensionContext) {
     registerEvents(context);
     registerWebview(context);
     registerAutocomplete(context);
+    registerCodeLens(context);
     registerHover();
     await applyItalicOverlay();
     await startExtension(context);
@@ -100,4 +102,3 @@ export async function restartExtension(context: vscode.ExtensionContext) {
     // start again
     await startExtension(context);
 }
-

--- a/client/src/services/codelens.ts
+++ b/client/src/services/codelens.ts
@@ -1,0 +1,41 @@
+import * as vscode from "vscode";
+import { extension } from "../state";
+import type { LJDiagnostic } from "../types/diagnostics";
+import { getDiagnosticRevealTarget } from "../webview/diagnostic-reveal";
+import { normalizeFilePath } from "../utils/utils";
+
+const codeLensEmitter = new vscode.EventEmitter<void>();
+
+export function registerCodeLens(context: vscode.ExtensionContext) {
+    context.subscriptions.push(
+        vscode.languages.registerCodeLensProvider("java", {
+            onDidChangeCodeLenses: codeLensEmitter.event,
+            provideCodeLenses(document) {
+                const file = normalizeFilePath(document.uri.fsPath);
+                return (extension.diagnostics || [])
+                    .map(diagnostic => createDiagnosticCodeLens(diagnostic, file))
+                    .filter((codeLens): codeLens is vscode.CodeLens => Boolean(codeLens));
+            }
+        })
+    );
+}
+
+export function refreshCodeLenses() {
+    codeLensEmitter.fire();
+}
+
+function createDiagnosticCodeLens(diagnostic: LJDiagnostic, file: string): vscode.CodeLens | undefined {
+    const targetDiagnostic = getDiagnosticRevealTarget(diagnostic);
+    if (!targetDiagnostic || targetDiagnostic.file !== file) return undefined;
+
+    const position = targetDiagnostic.position;
+    const range = new vscode.Range(
+        new vscode.Position(position.lineStart, position.colStart),
+        new vscode.Position(position.lineStart, position.colStart)
+    );
+    return new vscode.CodeLens(range, {
+        title: diagnostic.title,
+        command: "liquidjava.showView",
+        arguments: [targetDiagnostic]
+    });
+}

--- a/client/src/services/context.ts
+++ b/client/src/services/context.ts
@@ -139,13 +139,12 @@ function compareVariableNames(a: string, b: string): number {
 }
 
 function normalizeVariableRefinements(variables: LJVariable[]): LJVariable[] {
-    return Array.from(new Map(variables.map(v => [v.refinement, v])).values()).flatMap(v => {
+    return Array.from(new Map(variables.map(v => [`${v.internalName}:${v.refinement}`, v])).values()).flatMap(v => { // remove duplicates
         if (!v.refinement || v.refinement === "true") return []; // filter out trivial refinements
         if (v.refinement.includes("==")) {
             const [left, right] = v.refinement.split("==").map(s => s.trim());
             return left !== right ? [v] : []; // filter tautologies like x == x
         }
-        if (v.refinement.includes("!=") || v.refinement.includes(">") || v.refinement.includes("<")) return [v];
-        return [{ ...v, refinement: `${v.name} == ${v.refinement}` }];
+        return [v];
     });
 }

--- a/client/src/services/diagnostics.ts
+++ b/client/src/services/diagnostics.ts
@@ -3,6 +3,7 @@ import { extension } from "../state";
 import { LJDiagnostic } from "../types/diagnostics";
 import { StatusBarState, updateStatusBar } from "./status-bar";
 import { updateErrorAtCursor } from "./context";
+import { refreshCodeLenses } from "./codelens";
 
 /**
  * Handles LiquidJava diagnostics received from the language server
@@ -13,6 +14,7 @@ export function handleLJDiagnostics(diagnostics: LJDiagnostic[]) {
     const statusBarState: StatusBarState = containsError ? "failed" : "passed";
     updateStatusBar(statusBarState);
     extension.diagnostics = diagnostics;
+    refreshCodeLenses();
     updateErrorAtCursor();
     extension.webview?.sendMessage({ type: "diagnostics", diagnostics });
     if (extension.context)

--- a/client/src/services/hover.ts
+++ b/client/src/services/hover.ts
@@ -22,12 +22,6 @@ export function registerHover() {
                 if (method) hoverContent.appendCodeblock(formatMethodHover(method), 'java');
             }
 
-            const diagnostics = vscode.languages.getDiagnostics(document.uri);
-            const containsDiagnostic = !!diagnostics.find(d => d.range.contains(position) && d.source === 'liquidjava');
-            if (containsDiagnostic) {
-                if (hoverContent.value.length > 0) hoverContent.appendMarkdown(`\n\n`);
-                hoverContent.appendMarkdown(`[Open LiquidJava view](command:liquidjava.showView) for more details.`);
-            }
             if (hoverContent.value.length === 0) return null;
             return new vscode.Hover(hoverContent);
         }

--- a/client/src/services/webview.ts
+++ b/client/src/services/webview.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode";
 import { LiquidJavaWebviewProvider } from "../webview/provider";
 import { extension } from "../state";
+import type { DiagnosticRevealTarget } from "../types/diagnostics";
 
 /**
  * Initializes the webview panel for the extension
@@ -15,8 +16,9 @@ export function registerWebview(context: vscode.ExtensionContext) {
     );
     // show view command
     context.subscriptions.push(
-        vscode.commands.registerCommand("liquidjava.showView", async () => {
+        vscode.commands.registerCommand("liquidjava.showView", async (diagnostic?: DiagnosticRevealTarget) => {
             await vscode.commands.executeCommand("liquidJavaView.focus");
+            if (diagnostic) extension.webview.sendMessage({ type: "revealDiagnostic", diagnostic });
         })
     );
     // listen for messages from the webview

--- a/client/src/types/diagnostics.ts
+++ b/client/src/types/diagnostics.ts
@@ -111,3 +111,8 @@ export type ExternalMethodNotFoundWarning = BaseDiagnostic & {
 }
 
 export type RefinementMismatchError = RefinementError | StateRefinementError;
+
+export type DiagnosticRevealTarget = {
+    file: string;
+    position: SourcePosition;
+}

--- a/client/src/webview/diagnostic-reveal.ts
+++ b/client/src/webview/diagnostic-reveal.ts
@@ -1,0 +1,31 @@
+import type { DiagnosticRevealTarget, LJDiagnostic } from "../types/diagnostics";
+
+export function getDiagnosticRevealTargetKey(target: DiagnosticRevealTarget): string {
+    const { lineStart, colStart, lineEnd, colEnd } = target.position;
+    return `${target.file}:${lineStart}:${colStart}-${lineEnd}:${colEnd}`;
+}
+
+export function getDiagnosticRevealTarget(diagnostic: LJDiagnostic): DiagnosticRevealTarget | undefined {
+    if (!diagnostic.position) return undefined;
+    return {
+        file: diagnostic.position.file || diagnostic.file,
+        position: diagnostic.position
+    };
+}
+
+export function getDiagnosticRevealTargetFromKey(value?: string): DiagnosticRevealTarget | undefined {
+    const match = value?.match(/^(.*):(\d+):(\d+)-(\d+):(\d+)$/);
+    if (!match) return undefined;
+
+    const [, file, lineStart, colStart, lineEnd, colEnd] = match;
+    return {
+        file,
+        position: {
+            file,
+            lineStart: parseInt(lineStart, 10),
+            colStart: parseInt(colStart, 10),
+            lineEnd: parseInt(lineEnd, 10),
+            colEnd: parseInt(colEnd, 10)
+        }
+    };
+}

--- a/client/src/webview/script.ts
+++ b/client/src/webview/script.ts
@@ -9,6 +9,12 @@ import type { NavTab } from "./views/sections";
 import { renderDiagnosticsView } from "./views/diagnostics/diagnostics";
 import type { LJContext } from "../types/context";
 import { ContextSectionState, renderContextView } from "./views/context/context";
+import type { DiagnosticRevealTarget } from "../types/diagnostics";
+import { getDiagnosticRevealTargetFromKey, getDiagnosticRevealTargetKey } from "./diagnostic-reveal";
+
+type VSCodeApi = {
+    postMessage(message: unknown): void;
+};
 
 /**
  * Initializes the webview script
@@ -16,8 +22,9 @@ import { ContextSectionState, renderContextView } from "./views/context/context"
  * @param document
  * @param window
  */
-export function getScript(vscode: any, document: any, window: any) {
+export function getScript(vscode: VSCodeApi, document: Document, window: Window) {
     const root = document.getElementById('root');
+    if (!root) return;
     let diagnostics: LJDiagnostic[] = [];
     let showAllDiagnostics = false;
     let currentFile: string;
@@ -28,6 +35,7 @@ export function getScript(vscode: any, document: any, window: any) {
     let selectedTab: NavTab = 'diagnostics';
     let diagramOrientation: "LR" | "TB" = "TB";
     let currentDiagram: string = '';
+    let revealTimeout: ReturnType<typeof setTimeout> | undefined;
     const contextSectionState: ContextSectionState = {
         aliases: false,
         ghosts: false,
@@ -39,8 +47,8 @@ export function getScript(vscode: any, document: any, window: any) {
     vscode.postMessage({ type: 'ready' });    
     
     // on click
-    root.addEventListener('click', (e: any) => {
-        const target = e.target as any;
+    root.addEventListener('click', (e: MouseEvent) => {
+        const target = e.target instanceof Element ? e.target : null;
         if (!target) return;
 
         // context section toggle
@@ -87,6 +95,17 @@ export function getScript(vscode: any, document: any, window: any) {
                     character: parseInt(columnAttr, 10)
                 });
             }
+            return;
+        }
+
+        // reveal failing refinement diagnostic
+        if (target.classList.contains('diagnostic-reveal-btn')) {
+            e.preventDefault();
+            e.stopPropagation();
+
+            const revealTarget = getDiagnosticRevealTargetFromKey(target.getAttribute('data-diagnostic-target'));
+            if (!revealTarget) return;
+            revealDiagnostic(revealTarget);
             return;
         }
 
@@ -235,6 +254,9 @@ export function getScript(vscode: any, document: any, window: any) {
                 errorAtCursor = msg.errorAtCursor as RefinementMismatchError;
                 if (selectedTab === 'context') updateView();
                 break;
+            case 'revealDiagnostic':
+                revealDiagnostic(msg.diagnostic as DiagnosticRevealTarget);
+                break;
         }
     });
 
@@ -257,4 +279,31 @@ export function getScript(vscode: any, document: any, window: any) {
                 break;
         }
     }
+
+    function revealDiagnostic(target: DiagnosticRevealTarget) {
+        selectedTab = 'diagnostics';
+
+        const isVisibleInCurrentFile = showAllDiagnostics || !target.file || target.file.toLowerCase() === currentFile?.toLowerCase();
+        if (!isVisibleInCurrentFile) {
+            showAllDiagnostics = true;
+        }
+
+        updateView();
+        const element = Array.from(root.querySelectorAll<HTMLElement>('.diagnostic-item')).find(item =>
+            item.getAttribute('data-diagnostic-target') === getDiagnosticRevealTargetKey(target)
+        );
+        if (!element) return;
+
+        const previousRevealed = root.querySelector('.diagnostic-item.revealed');
+        if (previousRevealed) previousRevealed.classList.remove('revealed');
+        if (revealTimeout) clearTimeout(revealTimeout);
+
+        element.classList.add('revealed');
+        element.scrollIntoView({ block: 'center', behavior: 'smooth' });
+        revealTimeout = setTimeout(() => {
+            element.classList.remove('revealed');
+            revealTimeout = undefined;
+        }, 1800);
+    }
+
 }

--- a/client/src/webview/styles.ts
+++ b/client/src/webview/styles.ts
@@ -99,6 +99,30 @@ export function getStyles(): string {
             margin-bottom: 1rem;
             border-radius: 4px;
         }
+        .diagnostic-item.revealed {
+            outline: 2px solid var(--vscode-focusBorder);
+            animation: diagnostic-reveal-flash 1.8s ease-out;
+        }
+        @keyframes diagnostic-reveal-flash {
+            0% {
+                box-shadow: 0 0 0 0 var(--vscode-focusBorder);
+                transform: translateX(0);
+            }
+            12% {
+                box-shadow: 0 0 0 3px var(--vscode-focusBorder);
+                transform: translateX(3px);
+            }
+            24% {
+                transform: translateX(0);
+            }
+            55% {
+                box-shadow: 0 0 0 2px var(--vscode-focusBorder);
+            }
+            100% {
+                box-shadow: 0 0 0 0 transparent;
+                transform: translateX(0);
+            }
+        }
         .error-item {
             border-left: 4px solid var(--vscode-editorError-foreground);
         }
@@ -318,7 +342,8 @@ export function getStyles(): string {
         .context-variables-table td.failing-refinement {
             text-align: right;
         }
-        .failing-refinement .highlight-var-btn {
+        .failing-refinement .highlight-var-btn,
+        .failing-refinement .diagnostic-reveal-btn {
             display: flex;
             justify-content: flex-end;
             width: 100%;
@@ -350,26 +375,30 @@ export function getStyles(): string {
         .context-section-content.collapsed {
             display: none;
         }
-        .highlight-var-btn {
+        .highlight-var-btn,
+        .diagnostic-reveal-btn {
             background-color: transparent;
             border: none;
             transition: background-color 0.1s;
             text-align: left;
             padding: 0.2rem 0.8rem;
         }
-        .highlight-var-btn code {
+        .highlight-var-btn code,
+        .diagnostic-reveal-btn code {
             pointer-events: none;
         }
         .highlight-var-btn.selected {
             background-color: var(--vscode-button-background);
         }
-        .highlight-var-btn.error {
+        .highlight-var-btn.error,
+        .diagnostic-reveal-btn.error {
             background-color: #d6382f;
         }
         .highlight-var-btn.error.selected {
             background-color: #c92e26;
         }
-        .highlight-var-btn.error:hover {
+        .highlight-var-btn.error:hover,
+        .diagnostic-reveal-btn.error:hover {
             background-color: #c92e26;
         }
         .diagram-section {

--- a/client/src/webview/styles.ts
+++ b/client/src/webview/styles.ts
@@ -288,18 +288,40 @@ export function getStyles(): string {
             font-family: var(--vscode-editor-font-family);
             font-size: 0.9em;
         }
-        .context-section {
+        .context-section table {
+            width: 100%;
+            table-layout: fixed;
             margin-bottom: 1rem;
         }
+
+        .context-variables-table .context-variables-column {
+            width: 33.33%;
+        }
+
+        .context-variables-table .context-refinement-column {
+            width: 66.67%;
+        }
+
+        .context-variables-table th:first-child,
         .context-section table td:first-child {
             text-align: left;
-            flex: 1;
-            min-width: 0;
         }
+
+        .context-variables-table th:first-child {
+            padding-left: calc(0.75rem + 0.8rem);
+        }
+
+        .context-variables-table th:last-child,
         .context-section table td:last-child {
             text-align: right;
-            flex-shrink: 0;
-            white-space: nowrap;
+        }
+        .context-variables-table td.failing-refinement {
+            text-align: right;
+        }
+        .failing-refinement .highlight-var-btn {
+            display: flex;
+            justify-content: flex-end;
+            width: 100%;
         }
         .context-toggle-btn {
             display: flex;
@@ -349,34 +371,6 @@ export function getStyles(): string {
         }
         .highlight-var-btn.error:hover {
             background-color: #c92e26;
-        }
-        .failing-refinement {
-            position: relative;
-        }
-        .failing-refinement::after {
-            content: attr(data-tooltip);
-            position: absolute;
-            left: 0;
-            bottom: calc(100% + 0.35rem);
-            padding: 0.4rem 0.5rem;
-            border-radius: 4px;
-            background: var(--vscode-editorHoverWidget-background);
-            border: 1px solid var(--vscode-editorHoverWidget-border);
-            color: var(--vscode-editorHoverWidget-foreground);
-            font-size: 0.8rem;
-            line-height: 1.4;
-            white-space: nowrap;
-            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
-            opacity: 0;
-            visibility: hidden;
-            pointer-events: none;
-            transition: opacity 0.08s ease, visibility 0.08s ease;
-            transition-delay: 0.08s;
-            z-index: 10;
-        }
-        .failing-refinement:hover::after {
-            opacity: 1;
-            visibility: visible;
         }
         .diagram-section {
             margin-bottom: 1.5rem;

--- a/client/src/webview/styles.ts
+++ b/client/src/webview/styles.ts
@@ -362,7 +362,7 @@ export function getStyles(): string {
         .context-variables-table td.failing-refinement {
             text-align: center;
         }
-        .failing-refinement .highlight-var-btn {
+        .failing-refinement .diagnostic-reveal-btn {
             display: flex;
             justify-content: center;
             width: 100%;

--- a/client/src/webview/views/context/variables.ts
+++ b/client/src/webview/views/context/variables.ts
@@ -16,7 +16,7 @@ export function renderContextVariables(variables: LJVariable[], isExpanded: bool
                         </colgroup>
                         <thead>
                             <tr>
-                                <th>Variable</th>
+                                <th>Name</th>
                                 <th>Refinement</th>
                             </tr>
                         </thead>

--- a/client/src/webview/views/context/variables.ts
+++ b/client/src/webview/views/context/variables.ts
@@ -1,7 +1,6 @@
 import { LJVariable } from "../../../types/context";
 import { RefinementMismatchError } from "../../../types/diagnostics";
-import { escapeHtml, getSimpleName } from "../../utils";
-import { renderLocationLink, renderToggleSection, renderHighlightButton } from "../sections";
+import { renderToggleSection, renderHighlightButton } from "../sections";
 
 export function renderContextVariables(variables: LJVariable[], isExpanded: boolean, errorAtCursor?: RefinementMismatchError): string {
     const expected  = errorAtCursor ? errorAtCursor.type == "refinement-error" ? errorAtCursor.expected.value : errorAtCursor.expected : undefined;
@@ -10,15 +9,27 @@ export function renderContextVariables(variables: LJVariable[], isExpanded: bool
             ${renderToggleSection('Variables', 'context-vars', isExpanded)}
             <div id="context-vars" class="context-section-content ${isExpanded ? '' : 'collapsed'}">
                 ${variables.length > 0 ? /*html*/`
-                    <table>
+                    <table class="context-variables-table">
+                        <colgroup>
+                            <col class="context-variables-column">
+                            <col class="context-refinement-column">
+                        </colgroup>
+                        <thead>
+                            <tr>
+                                <th>Variable</th>
+                                <th>Refinement</th>
+                            </tr>
+                        </thead>
                         <tbody>
                             ${variables.map(variable => /*html*/`
                                 <tr>
-                                    <td>${renderHighlightButton(variable.position, variable.refinement)}</td>
-                                    <td><code>${getSimpleName(variable.type)}</code></td>
+                                    <td>${renderHighlightButton(variable.position, variable.name)}</td>
+                                    <td><code>${variable.refinement}</code></td>
                                 </tr>
                             `).join('')}
-                            ${errorAtCursor ? /*html*/`<tr><td><code class="failing-refinement" data-tooltip="${escapeHtml(errorAtCursor.title)}">${renderHighlightButton(errorAtCursor.position, '⊢ ' + expected, true)}</code></td><td></td></tr>` : ''}
+                            ${errorAtCursor ? /*html*/`
+                                <tr><td class="failing-refinement" colspan="2">${renderHighlightButton(errorAtCursor.position, '⊢ ' + expected, true)}</td></tr>`
+                            : ''}
                         </tbody>
                     </table>
                 `: '<p>No variables declared at the cursor position</p>'}

--- a/client/src/webview/views/context/variables.ts
+++ b/client/src/webview/views/context/variables.ts
@@ -1,6 +1,6 @@
 import { LJVariable } from "../../../types/context";
 import { RefinementMismatchError } from "../../../types/diagnostics";
-import { renderToggleSection, renderHighlightButton } from "../sections";
+import { renderToggleSection, renderHighlightButton, renderDiagnosticRevealButton } from "../sections";
 
 export function renderContextVariables(variables: LJVariable[], isExpanded: boolean, errorAtCursor?: RefinementMismatchError): string {
     const expected  = errorAtCursor ? errorAtCursor.type == "refinement-error" ? errorAtCursor.expected.value : errorAtCursor.expected : undefined;
@@ -27,8 +27,8 @@ export function renderContextVariables(variables: LJVariable[], isExpanded: bool
                                     <td><code>${variable.refinement}</code></td>
                                 </tr>
                             `).join('')}
-                            ${errorAtCursor ? /*html*/`
-                                <tr><td class="failing-refinement" colspan="2">${renderHighlightButton(errorAtCursor.position, '⊢ ' + expected, true)}</td></tr>`
+                            ${errorAtCursor?.position ? /*html*/`
+                                <tr><td class="failing-refinement" colspan="2">${renderDiagnosticRevealButton(errorAtCursor.position, '⊢ ' + expected)}</td></tr>`
                             : ''}
                         </tbody>
                     </table>

--- a/client/src/webview/views/diagnostics/errors.ts
+++ b/client/src/webview/views/diagnostics/errors.ts
@@ -1,4 +1,4 @@
-import { renderDiagnosticHeader, renderLocation, renderSection, renderCustomSection, renderTranslationTable,  } from "../sections";
+import { renderDiagnosticDataAttributes, renderDiagnosticHeader, renderLocation, renderSection, renderCustomSection, renderTranslationTable,  } from "../sections";
 import { renderDerivationNode } from "./derivation-nodes";
 import type {
     ArgumentMismatchError,
@@ -19,7 +19,7 @@ export function renderErrors(errors: LJError[], expandedErrors: Set<number>): st
                 const errorIndex = errors.indexOf(error);
                 const isExpanded = expandedErrors.has(errorIndex);
                 return /*html*/`
-                <li class="diagnostic-item error-item">
+                <li class="diagnostic-item error-item" ${renderDiagnosticDataAttributes(error)}>
                     ${renderError(error, errorIndex, isExpanded)}
                 </li>
             `;

--- a/client/src/webview/views/diagnostics/warnings.ts
+++ b/client/src/webview/views/diagnostics/warnings.ts
@@ -1,11 +1,11 @@
 import type { ExternalClassNotFoundWarning, ExternalMethodNotFoundWarning, LJWarning } from "../../../types/diagnostics";
-import { renderDiagnosticHeader, renderLocation, renderSection } from "../sections";
+import { renderDiagnosticDataAttributes, renderDiagnosticHeader, renderLocation, renderSection } from "../sections";
 
 export function renderWarnings(warnings: LJWarning[]): string {
     return /*html*/`
         <ul>
             ${warnings.map(warning => /*html*/`
-                <li class="diagnostic-item warning-item">
+                <li class="diagnostic-item warning-item" ${renderDiagnosticDataAttributes(warning)}>
                     ${renderWarning(warning)}
                 </li>
             `).join("")}

--- a/client/src/webview/views/sections.ts
+++ b/client/src/webview/views/sections.ts
@@ -1,4 +1,5 @@
 import type { LJDiagnostic, PlacementInCode, SourcePosition, TranslationTable } from "../../types/diagnostics";
+import { getDiagnosticRevealTarget, getDiagnosticRevealTargetKey } from "../diagnostic-reveal";
 
 export const renderMainHeader = (title: string, selectedTab: NavTab): string => /*html*/`
     <div class="header">
@@ -22,6 +23,11 @@ export const renderToggleSection = (title: string, targetId: string, isExpanded:
 
 export const renderDiagnosticHeader = (diagnostic: LJDiagnostic): string => /*html*/
     `<h3>${diagnostic.title}</h3><div class="diagnostic-header"><p>${diagnostic.message}</p></div>`;
+
+export function renderDiagnosticDataAttributes(diagnostic: LJDiagnostic): string {
+    const target = getDiagnosticRevealTarget(diagnostic);
+    return target ? `data-diagnostic-target="${getDiagnosticRevealTargetKey(target)}"` : "";
+}
 
 export const renderLocation = (diagnostic: LJDiagnostic): string => {
     if (!diagnostic.position || !diagnostic.file) return "";
@@ -66,6 +72,17 @@ export function renderHighlightButton(position: SourcePosition, content: string,
             data-end-line="${position.lineEnd}"
             data-end-column="${position.colEnd}"
             data-file="${position.file}"
+        >
+            <code>${content}</code>
+        </button>
+    `;
+}
+
+export function renderDiagnosticRevealButton(position: SourcePosition, content: string): string {
+    return /*html*/`
+        <button
+            class="diagnostic-reveal-btn error"
+            data-diagnostic-target="${getDiagnosticRevealTargetKey({ file: position.file, position })}"
         >
             <code>${content}</code>
         </button>


### PR DESCRIPTION
This PR adds a diagnostic CodeLens action that opens the LiquidJava webview, switches to the diagnostics explorer view, scrolls to the selected diagnostic, and highlights it. This also applies for failing refinements in the context debugger.

This allows users to easily map errors in the editor to their corresponding ones in the webview.

https://github.com/user-attachments/assets/c156d1af-910f-45b4-ac96-edbd40543b3a



