### PR TITLE
Add Hover Navigation to Method Refinements

### DIFF
--- a/client/src/services/hover.ts
+++ b/client/src/services/hover.ts
@@ -123,5 +123,5 @@ function formatMethodLocationLink(method: LJMethod): string | null {
     const uri = vscode.Uri.file(method.position.file).with({
         fragment: `L${method.position.lineStart + 1},${method.position.colStart + 1}`
     });
-    return `[Show Refinements](${uri.toString()})`;
+    return `[Go to Refinements Definition](${uri.toString()})`;
 }

--- a/client/src/services/hover.ts
+++ b/client/src/services/hover.ts
@@ -19,7 +19,11 @@ export function registerHover() {
                 hoverContent.appendCodeblock(formatRefinement(variable.mainRefinement), 'java');
             else {
                 const method = await getHoveredMethod(document, position);
-                if (method) hoverContent.appendCodeblock(formatMethodHover(method), 'java');
+                if (method) {
+                    hoverContent.appendCodeblock(formatMethodHover(method), 'java');
+                    const link = formatMethodLocationLink(method);
+                    if (link) hoverContent.appendMarkdown(`\n\n${link}`);
+                }
             }
 
             const diagnostics = vscode.languages.getDiagnostics(document.uri);
@@ -112,4 +116,12 @@ function formatMethodHover(method: LJMethod): string {
             .filter(s => s.from || s.to)
             .map(s => formatStateRefinement(s.from, s.to))
     ].filter(Boolean).join('\n');
+}
+
+function formatMethodLocationLink(method: LJMethod): string | null {
+    if (!method.position?.file) return null;
+    const uri = vscode.Uri.file(method.position.file).with({
+        fragment: `L${method.position.lineStart + 1},${method.position.colStart + 1}`
+    });
+    return `[Open method definition](${uri.toString()})`;
 }

--- a/client/src/services/hover.ts
+++ b/client/src/services/hover.ts
@@ -123,5 +123,5 @@ function formatMethodLocationLink(method: LJMethod): string | null {
     const uri = vscode.Uri.file(method.position.file).with({
         fragment: `L${method.position.lineStart + 1},${method.position.colStart + 1}`
     });
-    return `[Open method definition](${uri.toString()})`;
+    return `[Show Refinements](${uri.toString()})`;
 }

--- a/client/src/types/context.ts
+++ b/client/src/types/context.ts
@@ -40,6 +40,7 @@ export type LJMethod = {
   returnRefinement: string;
   parameters: LJVariable[];
   stateRefinements: LJMethodStateRefinement[];
+  position: SourcePosition | null;
 }
 
 export type LJContext = {

--- a/server/src/main/java/LJDiagnosticsHandler.java
+++ b/server/src/main/java/LJDiagnosticsHandler.java
@@ -23,8 +23,6 @@ import utils.PathUtils;
 public class LJDiagnosticsHandler {
 
     private static final String SOURCE = "liquidjava";
-    private static final String LSP_FLAG = "-lsp";
-
     /**
      * Generates LJDiagnostics for the given URI
      * @param uri the document URI
@@ -35,7 +33,8 @@ public class LJDiagnosticsHandler {
         List<LJError> errors = new ArrayList<>();
         List<LJWarning> warnings = new ArrayList<>();
         try {
-            CommandLineLauncher.main(new String[] { LSP_FLAG, path });
+            CommandLineLauncher.cmdArgs.lspMode = true;
+            CommandLineLauncher.launch(path);
             Diagnostics diagnostics = Diagnostics.getInstance();
             if (diagnostics.foundWarning()) {
                 warnings.addAll(diagnostics.getWarnings());

--- a/server/src/main/java/dtos/context/MethodDTO.java
+++ b/server/src/main/java/dtos/context/MethodDTO.java
@@ -3,6 +3,7 @@ package dtos.context;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import dtos.diagnostics.SourcePositionDTO;
 import liquidjava.processor.context.ObjectState;
 import liquidjava.processor.context.RefinedFunction;
 import liquidjava.rj_language.Predicate;
@@ -16,7 +17,8 @@ public record MethodDTO(
     String targetClass,
     String returnRefinement,
     List<VariableDTO> parameters,
-    List<StateRefinementDTO> stateRefinements
+    List<StateRefinementDTO> stateRefinements,
+    SourcePositionDTO position
 ) {
     public static MethodDTO from(RefinedFunction refinedFunction) {
         return new MethodDTO(
@@ -24,7 +26,8 @@ public record MethodDTO(
             refinedFunction.getTargetClass(),
             format(refinedFunction.getRefReturn()),
             refinedFunction.getArguments().stream().map(VariableDTO::from).filter(v -> v != null).collect(Collectors.toList()),
-            refinedFunction.getAllStates().stream().map(StateRefinementDTO::from).collect(Collectors.toList())
+            refinedFunction.getAllStates().stream().map(StateRefinementDTO::from).collect(Collectors.toList()),
+            SourcePositionDTO.from(refinedFunction.getPlacementInCode().getPosition())
         );
     }
 


### PR DESCRIPTION
This PR adds a link to the hover for methods to go to the location where their refinements were defined.

<img width="884" height="430" alt="image" src="https://github.com/user-attachments/assets/e1cfa202-152b-4b68-9c4d-d7768c7ee2d7" />

Clicking "Show Refinements" opens the file in the method's position.

<img width="693" height="354" alt="image" src="https://github.com/user-attachments/assets/c690a4a2-0e02-46cc-af40-ae47124d2781" />
