### PR TITLE
Remove Redundant Messages

### DIFF
--- a/client/src/webview/views/diagnostics/errors.ts
+++ b/client/src/webview/views/diagnostics/errors.ts
@@ -58,7 +58,8 @@ const errorContentRenderers: Partial<Record<LJError['type'], (error: LJError) =>
 };
 
 export function renderError(error: LJError, errorIndex: number, isExpanded: boolean): string {
-    const header = renderDiagnosticHeader(error);
+    const showMessage = error.type !== 'refinement-error' && error.type !== 'state-refinement-error';
+    const header = renderDiagnosticHeader(error, showMessage);
     const content = errorContentRenderers[error.type]?.(error) ?? '';
     const location = renderLocation(error);
     const extra = renderExtra(error, errorIndex, isExpanded);

--- a/client/src/webview/views/diagnostics/errors.ts
+++ b/client/src/webview/views/diagnostics/errors.ts
@@ -30,13 +30,11 @@ export function renderErrors(errors: LJError[], expandedErrors: Set<number>): st
 
 const errorContentRenderers: Partial<Record<LJError['type'], (error: LJError) => string>> = {
     'refinement-error': (e: RefinementError) => /*html*/`
-        ${e.customMessage ? renderSection('Message', e.customMessage) : ''}
         ${renderCustomSection('Expected', renderDerivationNode(e, e.expected, 'expected'))}
         ${renderCustomSection('Found', renderDerivationNode(e, e.found, 'found'))}
         ${e.counterexample ? renderSection('Counterexample', e.counterexample) : ''}
     `,
     'state-refinement-error': (e: StateRefinementError) => /*html*/`
-        ${e.customMessage ? renderSection('Message', e.customMessage) : ''}
         ${renderSection('Expected', e.expected)}
         ${renderSection('Found', e.found)}
     `,
@@ -58,9 +56,9 @@ const errorContentRenderers: Partial<Record<LJError['type'], (error: LJError) =>
 };
 
 export function renderError(error: LJError, errorIndex: number, isExpanded: boolean): string {
-    const showMessage = error.type !== 'refinement-error' && error.type !== 'state-refinement-error';
-    const header = renderDiagnosticHeader(error, showMessage);
-    const content = errorContentRenderers[error.type]?.(error) ?? '';
+    const message = error.type === 'refinement-error' || error.type === 'state-refinement-error' ? error.customMessage : error.message;
+    const header = renderDiagnosticHeader(error.title, message || '');
+    const content = errorContentRenderers[error.type]?.(error) || '';
     const location = renderLocation(error);
     const extra = renderExtra(error, errorIndex, isExpanded);
     return /*html*/`${header}${content}${location}${extra}`;

--- a/client/src/webview/views/diagnostics/warnings.ts
+++ b/client/src/webview/views/diagnostics/warnings.ts
@@ -24,7 +24,7 @@ const warningContentRenderers: Partial<Record<LJWarning['type'], (warning: LJWar
 };
 
 export function renderWarning(warning: LJWarning): string {
-    const header = renderDiagnosticHeader(warning);
+    const header = renderDiagnosticHeader(warning.title, warning.message);
     const content = warningContentRenderers[warning.type]?.(warning) ?? '';
     const location = renderLocation(warning);
     return /*html*/`${header}${content}${location}`;

--- a/client/src/webview/views/sections.ts
+++ b/client/src/webview/views/sections.ts
@@ -20,8 +20,8 @@ export const renderToggleSection = (title: string, targetId: string, isExpanded:
     </button>
     `;
 
-export const renderDiagnosticHeader = (diagnostic: LJDiagnostic, showMessage = true): string => /*html*/
-    `<h3>${diagnostic.title}</h3>${showMessage ? /*html*/`<div class="diagnostic-header"><p>${diagnostic.message}</p></div>` : ''}`;
+export const renderDiagnosticHeader = (title: string, message: string): string => /*html*/
+    `<h3>${title}</h3><div class="diagnostic-header"><p>${message}</p></div>`;
 
 export const renderLocation = (diagnostic: LJDiagnostic): string => {
     if (!diagnostic.position || !diagnostic.file) return "";

--- a/client/src/webview/views/sections.ts
+++ b/client/src/webview/views/sections.ts
@@ -20,8 +20,8 @@ export const renderToggleSection = (title: string, targetId: string, isExpanded:
     </button>
     `;
 
-export const renderDiagnosticHeader = (diagnostic: LJDiagnostic): string => /*html*/
-    `<h3>${diagnostic.title}</h3><div class="diagnostic-header"><p>${diagnostic.message}</p></div>`;
+export const renderDiagnosticHeader = (diagnostic: LJDiagnostic, showMessage = true): string => /*html*/
+    `<h3>${diagnostic.title}</h3>${showMessage ? /*html*/`<div class="diagnostic-header"><p>${diagnostic.message}</p></div>` : ''}`;
 
 export const renderLocation = (diagnostic: LJDiagnostic): string => {
     if (!diagnostic.position || !diagnostic.file) return "";


### PR DESCRIPTION
This PR hides the messages for the refinement and state refinements which were redundant.

### Example

#### Before

<img width="989" height="668" alt="image" src="https://github.com/user-attachments/assets/ee3aa706-ceaf-4630-b7be-af828b066261" />

#### After

<img width="990" height="609" alt="image" src="https://github.com/user-attachments/assets/c8fa499d-fdb1-4733-b4b0-f7498041d9b6" />
