### PR TITLE
Clear Extension State on Stop

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -9,7 +9,7 @@ import { registerWebview } from "./services/webview";
 import { registerHover } from "./services/hover";
 import { registerEvents } from "./services/events";
 import { registerAutocomplete } from "./services/autocomplete";
-import { registerCodeLens } from "./services/codelens";
+import { refreshCodeLenses, registerCodeLens } from "./services/codelens";
 import { runLanguageServer, stopLanguageServer } from "./lsp/server";
 import { runClient, stopClient } from "./lsp/client";
 
@@ -39,6 +39,7 @@ export async function deactivate() {
     extension.logger?.client.info("Deactivating LiquidJava extension...");
     await stopClient("Extension was deactivated");
     await stopLanguageServer();
+    resetExtension();
 }
 
 /**
@@ -82,6 +83,7 @@ export async function stopExtension() {
         return;
     }
     extension.logger?.client.info("Stopping LiquidJava...");
+    resetExtension();
     await stopClient("Extension stop command");
     await stopLanguageServer();
 }
@@ -102,4 +104,17 @@ export async function restartExtension(context: vscode.ExtensionContext) {
     
     // start again
     await startExtension(context);
+}
+
+export function isExtensionRunning(): boolean {
+    return extension.status !== "stopped" && Boolean(extension.client);
+}
+
+export function resetExtension() {
+    extension.diagnostics = [];
+    extension.errorAtCursor = undefined;
+    refreshCodeLenses();
+    extension.webview?.sendMessage({ type: "diagnostics", diagnostics: [] });
+    if (extension.context)
+        extension.webview?.sendMessage({ type: "context", context: extension.context, errorAtCursor: extension.errorAtCursor });
 }

--- a/client/src/services/autocomplete.ts
+++ b/client/src/services/autocomplete.ts
@@ -4,6 +4,7 @@ import type { LJVariable, LJContext, LJGhost, LJAlias } from "../types/context";
 import { getSimpleName } from "../utils/utils";
 import { LIQUIDJAVA_ANNOTATION_START, LJAnnotation } from "../utils/constants";
 import { filterDuplicateVariables, filterInstanceVariables } from "./context";
+import { isExtensionRunning } from "../extension";
 
 type CompletionItemOptions = {
     name: string;
@@ -25,6 +26,8 @@ export function registerAutocomplete(context: vscode.ExtensionContext) {
     context.subscriptions.push(
         vscode.languages.registerCompletionItemProvider("java", {
             provideCompletionItems(document, position, _token, completionContext) {
+                if (!isExtensionRunning()) return null;
+
                 const annotation = getActiveLiquidJavaAnnotation(document, position);
                 if (!annotation || !extension.context) return null;
 

--- a/client/src/services/codelens.ts
+++ b/client/src/services/codelens.ts
@@ -3,6 +3,7 @@ import { extension } from "../state";
 import type { LJDiagnostic } from "../types/diagnostics";
 import { getDiagnosticRevealTarget } from "../webview/diagnostic-reveal";
 import { normalizeFilePath } from "../utils/utils";
+import { isExtensionRunning } from "../extension";
 
 const codeLensEmitter = new vscode.EventEmitter<void>();
 
@@ -11,6 +12,8 @@ export function registerCodeLens(context: vscode.ExtensionContext) {
         vscode.languages.registerCodeLensProvider("java", {
             onDidChangeCodeLenses: codeLensEmitter.event,
             provideCodeLenses(document) {
+                if (!isExtensionRunning()) return [];
+
                 const file = normalizeFilePath(document.uri.fsPath);
                 return (extension.diagnostics || [])
                     .map(diagnostic => createDiagnosticCodeLens(diagnostic, file))

--- a/client/src/services/hover.ts
+++ b/client/src/services/hover.ts
@@ -4,6 +4,7 @@ import type { LJMethod, LJVariable } from '../types/context';
 import { getSelectionContextVariables } from './context';
 import { getOriginalVariableName, normalizeFilePath } from '../utils/utils';
 import { definitionMatchesClass, getDefinitions } from './definition';
+import { isExtensionRunning } from '../extension';
 
 /**
  * Initializes hover provider for LiquidJava diagnostics
@@ -11,6 +12,8 @@ import { definitionMatchesClass, getDefinitions } from './definition';
 export function registerHover() {
     vscode.languages.registerHoverProvider('java', {
         async provideHover(document, position) {
+            if (!isExtensionRunning()) return null;
+
             const hoverContent = new vscode.MarkdownString();
             hoverContent.isTrusted = true;
 


### PR DESCRIPTION
This PR stops stale LiquidJava editor UI from appearing after the extension is stopped. Clears cached diagnostics state, refreshes CodeLens, and disables CodeLens, hover, and autocomplete providers when the extension is not running.