### PR TITLE
Fix Variable Expansion

### DIFF
--- a/client/src/webview/script.ts
+++ b/client/src/webview/script.ts
@@ -90,8 +90,8 @@ export function getScript(vscode: VSCodeApi, document: Document, window: Window)
             return;
         }
 
-        // location link or variable click
-        const locationTarget = target.closest?.('.location-link, .node-var');
+        // location link click
+        const locationTarget = target.closest?.('.location-link');
         if (locationTarget) {
             e.preventDefault();
             e.stopPropagation();

--- a/client/src/webview/views/diagnostics/derivation-nodes.ts
+++ b/client/src/webview/views/diagnostics/derivation-nodes.ts
@@ -32,21 +32,14 @@ function renderJsonTree(
     const hasOrigin = Boolean("origin" in node && node.origin);
     const isExpanded = expandedPaths.has(path);
     if (hasOrigin && isExpanded && "origin" in node) {
-        return renderJsonTree(error, node.origin, errorId, path, expandedPaths);
+        return renderJsonTree(error, node.origin, errorId, `${path}.origin`, expandedPaths);
     }
     
     // VarDerivationNode
     if ("var" in node) {
-        const placement = error.translationTable?.[node.var];
-        if (!placement) return `<span class="node-var">${renderHighlightedInlineExpression(node.var)}</span>`;
-        
-        const filePath = (placement as any)?.file ?? error.file;
-        const filename = filePath.split("/").pop() ?? "";
-        const tooltipData = `${filename}:${(placement.position?.lineStart ?? 0) + 1}`;
-        const classes = `node-var tooltip clickable ${hasOrigin ? "derivable-node" : ""}`.trim();
+        const classes = `node-var ${hasOrigin ? "derivable-node clickable" : ""}`.trim();
         const attrs = hasOrigin ? ` data-node-path="${path}" data-error-id="${errorId}"` : "";
-        const fileAttr = ` data-file="${filePath}" data-line="${placement.position?.lineStart ?? 0}" data-column="${placement.position?.colStart ?? 0}"`;
-        return `<span class="${classes}" data-tooltip="${escapeHtml(tooltipData)}"${fileAttr}${attrs}>${renderHighlightedInlineExpression(node.var)}</span>`;
+        return `<span class="${classes}"${attrs}>${renderHighlightedInlineExpression(node.var)}</span>`;
     }
 
     // ValDerivationNode


### PR DESCRIPTION
This PR removes the jump to source code from derivation variables so clicks only expand the derivation tree. This lets chained origins like `6` -> `b` -> `a` render step by step instead of navigating to the variable location and makes the interface more consistent.