### PR TITLE
Highlight Relevant Context

### DIFF
--- a/client/src/webview/script.ts
+++ b/client/src/webview/script.ts
@@ -362,7 +362,6 @@ export function getScript(vscode: VSCodeApi, document: Document, window: Window)
             filePath: target.file,
             line: target.position.lineEnd,
             character: target.position.colEnd,
-            highlightRange: target.position,
         });
         updateView();
     }

--- a/client/src/webview/script.ts
+++ b/client/src/webview/script.ts
@@ -30,7 +30,6 @@ export function getScript(vscode: VSCodeApi, document: Document, window: Window)
     let diagnostics: LJDiagnostic[] | undefined;
     let showAllDiagnostics = false;
     let currentFile: string;
-    const expandedErrors = new Set<number>();
     let stateMachine: LJStateMachine;
     let context: LJContext;
     let errorAtCursor: RefinementMismatchError;
@@ -121,6 +120,17 @@ export function getScript(vscode: VSCodeApi, document: Document, window: Window)
             return;
         }
 
+        const diagnosticContextButton = target.closest?.('.diagnostic-context-btn');
+        if (diagnosticContextButton) {
+            e.preventDefault();
+            e.stopPropagation();
+
+            const revealTarget = getDiagnosticRevealTargetFromKey(diagnosticContextButton.getAttribute('data-diagnostic-target'));
+            if (!revealTarget) return;
+            revealContextForDiagnostic(revealTarget);
+            return;
+        }
+
         // derivation expansion click
         const derivableNode = target.closest?.('.derivable-node');
         if (derivableNode) {
@@ -195,21 +205,6 @@ export function getScript(vscode: VSCodeApi, document: Document, window: Window)
             e.stopPropagation();
             if (!currentDiagram) return
             copyDiagramToClipboard(copyDiagramButton, currentDiagram);
-            return;
-        }
-
-        // toggle show more/less for errors
-        if (target.classList.contains('show-more-button')) {
-            e.stopPropagation();
-            const errorIndex = parseInt(target.getAttribute('data-error-index') || '-1', 10);
-            if (errorIndex >= 0) {
-                if (expandedErrors.has(errorIndex)) {
-                    expandedErrors.delete(errorIndex);
-                } else {
-                    expandedErrors.add(errorIndex);
-                }
-                updateView();
-            }
             return;
         }
 
@@ -318,7 +313,7 @@ export function getScript(vscode: VSCodeApi, document: Document, window: Window)
         switch (selectedTab) {
             case 'diagnostics':
                 root.innerHTML = diagnostics
-                    ? renderDiagnosticsView(diagnostics, showAllDiagnostics, currentFile, expandedErrors)
+                    ? renderDiagnosticsView(diagnostics, showAllDiagnostics, currentFile)
                     : renderLoading();
                 break;
             case 'fsm': {
@@ -358,6 +353,18 @@ export function getScript(vscode: VSCodeApi, document: Document, window: Window)
             element.classList.remove('revealed');
             revealTimeout = undefined;
         }, 1800);
+    }
+
+    function revealContextForDiagnostic(target: DiagnosticRevealTarget) {
+        selectedTab = 'context';
+        vscode.postMessage({
+            type: 'openFile',
+            filePath: target.file,
+            line: target.position.lineEnd,
+            character: target.position.colEnd,
+            highlightRange: target.position,
+        });
+        updateView();
     }
 
 }

--- a/client/src/webview/styles.ts
+++ b/client/src/webview/styles.ts
@@ -161,7 +161,7 @@ export function getStyles(): string {
         }
         .diagnostic-item {
             background-color: var(--vscode-textCodeBlock-background);
-            padding: 0.5rem 3rem 0.5rem 1rem;
+            padding: 0.5rem 5rem 0.5rem 1rem;
             margin-bottom: 1rem;
             border-radius: 4px;
             position: relative;
@@ -176,10 +176,10 @@ export function getStyles(): string {
             line-height: 1;
             pointer-events: none;
         }
-        .copy-diagnostic-btn {
+        .copy-diagnostic-btn,
+        .diagnostic-context-btn {
             position: absolute;
             top: 0.5rem;
-            right: 0.5rem;
             display: inline-flex;
             align-items: center;
             justify-content: center;
@@ -193,12 +193,20 @@ export function getStyles(): string {
             opacity: 0.65;
             transition: background-color 0.16s ease, border-color 0.16s ease, opacity 0.16s ease, transform 0.16s ease;
         }
-        .copy-diagnostic-btn:hover {
+        .copy-diagnostic-btn {
+            right: 0.5rem;
+        }
+        .diagnostic-context-btn {
+            right: 2.5rem;
+        }
+        .copy-diagnostic-btn:hover,
+        .diagnostic-context-btn:hover {
             background: var(--vscode-editor-background);
             border-color: var(--vscode-widget-border);
             opacity: 1;
         }
-        .copy-diagnostic-btn:disabled {
+        .copy-diagnostic-btn:disabled,
+        .diagnostic-context-btn:disabled {
             opacity: 0.8;
             cursor: default;
         }
@@ -370,20 +378,6 @@ export function getStyles(): string {
         button:hover {
             background-color: var(--vscode-button-hoverBackground);
         }
-        .show-more-button {
-            display: block;
-            width: 100%;
-            margin: 0.5rem auto;
-            padding: 0.5rem;
-            background-color: transparent;
-            border: none;
-            color: var(--vscode-foreground);
-            opacity: 0.7;
-            font-size: 1rem;
-        }
-        .show-more-button:hover {
-            background-color: var(--vscode-editor-background);
-        }
         .underline-button {
             color: var(--vscode-foreground);
             text-align: center;
@@ -399,9 +393,6 @@ export function getStyles(): string {
         }
         .underline-button:hover {
             background: none;
-        }
-        .extra-content {
-            margin-top: 1rem;
         }
         .tooltip:hover::after {
             content: attr(data-tooltip);
@@ -548,8 +539,10 @@ export function getStyles(): string {
             word-break: normal;
         }
 
-        .context-variables-table th:first-child,
-        .translation-table th:first-child {
+        .context-variable-relevant td:first-child {
+            border-left: 2px solid var(--vscode-errorForeground);
+        }
+        .context-variables-table th:first-child {
             padding-left: calc(0.75rem + 0.8rem);
         }
         .context-aliases-table td:last-child,

--- a/client/src/webview/views/context/variables.ts
+++ b/client/src/webview/views/context/variables.ts
@@ -1,11 +1,12 @@
 import { LJVariable } from "../../../types/context";
 import { RefinementMismatchError } from "../../../types/diagnostics";
 import { renderHighlightedInlineExpression } from "../../highlighting";
-import { escapeHtml, getSimpleName } from "../../utils";
+import { escapeHtml } from "../../utils";
 import { renderToggleSection, renderHighlightButton, renderDiagnosticRevealButton } from "../sections";
 
 export function renderContextVariables(variables: LJVariable[], isExpanded: boolean, errorAtCursor?: RefinementMismatchError): string {
     const expected = errorAtCursor ? errorAtCursor.expected.value : undefined;
+    const relevantNames = new Set(Object.keys(errorAtCursor?.translationTable || {}));
     return /*html*/`
         <div class="context-section">
             ${renderToggleSection('Variables', 'context-vars', isExpanded)}
@@ -23,12 +24,14 @@ export function renderContextVariables(variables: LJVariable[], isExpanded: bool
                             </tr>
                         </thead>
                         <tbody>
-                            ${variables.map(variable => /*html*/`
-                                <tr>
-                                    <td>${renderHighlightButton(variable.position!, getSimpleName(variable.name))}</td>
+                            ${variables.map(variable => {
+                                const isRelevant = relevantNames.has(variable.name);
+                                return /*html*/`
+                                <tr class="${isRelevant ? 'context-variable-relevant' : ''}">
+                                    <td>${renderHighlightButton(variable.position!, variable.name)}</td>
                                     <td><code>${renderHighlightedInlineExpression(variable.refinement)}</code></td>
                                 </tr>
-                            `).join('')}
+                            `}).join('')}
                             ${errorAtCursor ? renderFailingRefinement(errorAtCursor, expected!) : ''}
                         </tbody>
                     </table>

--- a/client/src/webview/views/context/variables.ts
+++ b/client/src/webview/views/context/variables.ts
@@ -1,7 +1,7 @@
 import { LJVariable } from "../../../types/context";
 import { RefinementMismatchError } from "../../../types/diagnostics";
 import { renderHighlightedInlineExpression } from "../../highlighting";
-import { escapeHtml } from "../../utils";
+import { escapeHtml, getSimpleName } from "../../utils";
 import { renderToggleSection, renderHighlightButton, renderDiagnosticRevealButton } from "../sections";
 
 export function renderContextVariables(variables: LJVariable[], isExpanded: boolean, errorAtCursor?: RefinementMismatchError): string {
@@ -25,10 +25,11 @@ export function renderContextVariables(variables: LJVariable[], isExpanded: bool
                         </thead>
                         <tbody>
                             ${variables.map(variable => {
+                                const displayName = getSimpleName(variable.name);
                                 const isRelevant = relevantNames.has(variable.name);
                                 return /*html*/`
                                 <tr class="${isRelevant ? 'context-variable-relevant' : ''}">
-                                    <td>${renderHighlightButton(variable.position!, variable.name)}</td>
+                                    <td>${renderHighlightButton(variable.position!, displayName)}</td>
                                     <td><code>${renderHighlightedInlineExpression(variable.refinement)}</code></td>
                                 </tr>
                             `}).join('')}

--- a/client/src/webview/views/diagnostics/diagnostics.ts
+++ b/client/src/webview/views/diagnostics/diagnostics.ts
@@ -9,7 +9,6 @@ export function renderDiagnosticsView(
     diagnostics: LJDiagnostic[],
     showAll: boolean,
     currentFile: string | undefined,
-    expandedErrors: Set<number>,
 ): string {
     const fileDiagnostics = diagnostics.filter(diagnostic => diagnostic.file?.toLowerCase() === currentFile?.toLowerCase() || !diagnostic.file);
     const displayDiagnostics = showAll ? diagnostics : fileDiagnostics;
@@ -35,7 +34,7 @@ export function renderDiagnosticsView(
                 `
             }
             <div class="content">
-                ${renderErrors(errors, expandedErrors)}
+                ${renderErrors(errors)}
                 ${renderWarnings(warnings)}
                 ${displayDiagnostics.length > 0 && hiddenErrors > 0 ? /*html*/`
                     <p class="more-indicator">(+${hiddenErrors} error${hiddenErrors !== 1 ? 's' : ''})</p>

--- a/client/src/webview/views/diagnostics/errors.ts
+++ b/client/src/webview/views/diagnostics/errors.ts
@@ -1,4 +1,4 @@
-import { renderDiagnosticDataAttributes, renderExpressionSection, renderDiagnosticHeader, renderSection, renderCustomSection, renderTranslationTable, renderLocation,  } from "../sections";
+import { renderDiagnosticDataAttributes, renderExpressionSection, renderDiagnosticHeader, renderCustomSection, renderLocation, renderDiagnosticContextButton } from "../sections";
 import { renderDerivationNode } from "./derivation-nodes";
 import type {
     ArgumentMismatchError,
@@ -11,19 +11,18 @@ import type {
     StateConflictError,
     StateRefinementError,
     SyntaxError,
-    TranslationTable,
 } from "../../../types/diagnostics";
 import { renderCopyDiagnosticButton } from "./diagnostics";
 
-export function renderErrors(errors: LJError[], expandedErrors: Set<number>): string {
+export function renderErrors(errors: LJError[]): string {
     return /*html*/`
         <ul>
             ${errors.map((error, index) => {
-                const isExpanded = expandedErrors.has(index);
                 return /*html*/`
                 <li class="diagnostic-item error-item" ${renderDiagnosticDataAttributes(error)}>
+                    ${renderDiagnosticContextAction(error)}
                     ${renderCopyDiagnosticButton('error', index)}
-                    ${renderError(error, index, isExpanded)}
+                    ${renderError(error)}
                 </li>
             `;
             }).join("")}
@@ -62,25 +61,15 @@ const errorContentRenderers: ErrorRendererMap = {
     'custom-error': (_: CustomError) => "",
 };
 
-export function renderError(error: LJError, errorIndex: number, isExpanded: boolean): string {
+export function renderError(error: LJError): string {
     const message = error.type === 'refinement-error' || error.type === 'state-refinement-error' ? error.customMessage : error.message;
     const header = renderDiagnosticHeader(error.title, message || '');
     const content = (errorContentRenderers[error.type] as (error: LJError) => string)?.(error) || '';
     const location = renderLocation(error);
-    const extra = renderExtra(error, errorIndex, isExpanded);
-    return /*html*/`${header}${content}${location}${extra}`;
+    return /*html*/`${header}${content}${location}`;
 }
 
-function renderExtra(error: LJError, errorIndex: number, isExpanded: boolean): string {
-    const button = /*html*/`
-        <button class="show-more-button" data-error-index="${errorIndex}" title="Toggle show extra information about the diagnostic">
-            ${isExpanded ? '↑' : '↓'}
-        </button>
-    `;
-    
-    let extra = "";
-    if (Object.prototype.hasOwnProperty.call(error, 'translationTable')) {
-        extra += renderTranslationTable((error as any).translationTable as TranslationTable);
-    }
-    return extra ? isExpanded ? /*html*/`${button}<div class="extra-content">${extra}</div>` : button : "";
+function renderDiagnosticContextAction(error: LJError): string {
+    if (error.type !== 'refinement-error' && error.type !== 'state-refinement-error') return "";
+    return renderDiagnosticContextButton(error.position);
 }

--- a/client/src/webview/views/sections.ts
+++ b/client/src/webview/views/sections.ts
@@ -1,8 +1,8 @@
-import type { LJDiagnostic, PlacementInCode, SourcePosition, TranslationTable } from "../../types/diagnostics";
+import type { LJDiagnostic, SourcePosition } from "../../types/diagnostics";
 import { escapeHtml } from "../utils";
 import { renderHighlightedExpression, renderHighlightedInlineExpression } from "../highlighting";
 import { getDiagnosticRevealTarget, getDiagnosticRevealTargetKey } from "../diagnostic-reveal";
-import { renderCodicon } from "../icons";
+import { renderCodicon, renderCodiconButton } from "../icons";
 
 export const renderMainHeader = (title: string, selectedTab: NavTab): string => /*html*/`
     <div class="header">
@@ -40,36 +40,6 @@ export const renderLocation = (diagnostic: LJDiagnostic): string => {
     return renderCustomSection("Location", /*html*/`<pre>${renderLocationLink(diagnostic.position)}</pre>`);
 };
 
-export function renderTranslationTable(translationTable: TranslationTable): string {  
-    const entries = Object.entries(translationTable).sort((a, b) => a[0].localeCompare(b[0])); // sort by variable name
-    if (entries.length === 0) return '';
-    
-    return /*html*/`
-        <div class="translation-table">
-            <h3>Context Variables</h3>
-            <table>
-                <thead>
-                    <tr>
-                        <th>Name</th>
-                        <th>Source</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    ${entries.map(([variable, placement]: [string, PlacementInCode]) => {
-                        if (!placement.position) return ''
-                        return /*html*/`
-                            <tr>
-                                <td>${renderHighlightButton(placement.position, variable)}</td>
-                                <td><code>${renderHighlightedInlineExpression(placement.text)}</code></td>
-                            </tr>
-                        `;
-                    }).join('')}
-                </tbody>
-            </table>
-        </div>
-    `;
-}
-
 export function renderHighlightButton(position: SourcePosition, content: string, error: boolean = false): string {
     return /*html*/`
         <button
@@ -83,6 +53,15 @@ export function renderHighlightButton(position: SourcePosition, content: string,
             <code>${renderHighlightedInlineExpression(content)}</code>
         </button>
     `;
+}
+
+export function renderDiagnosticContextButton(position?: SourcePosition | null): string {
+    if (!position?.file) return "";
+    return renderCodiconButton("symbol-variable", {
+        className: "diagnostic-context-btn",
+        title: "View related context",
+        attributes: `data-diagnostic-target="${getDiagnosticRevealTargetKey({ file: position.file, position })}"`,
+    });
 }
 
 export function renderDiagnosticRevealButton(position: SourcePosition, content: string): string {


### PR DESCRIPTION
This PR removes the expandable translation table in the diagnostic view (for refinement and state refinement errors) and adds a button to jump to the error position and go the context tab, where it highlights the relevant context variables for the failing assertion, which are the ones present in the translation table.

<img width="1092" height="704" alt="demo" src="https://github.com/user-attachments/assets/dbea1ee4-9c1e-488f-ba5d-9dbd1085413c" />
