### PR TITLE
Improve Diagnostics Webview UI

### DIFF
--- a/client/src/services/webview.ts
+++ b/client/src/services/webview.ts
@@ -9,6 +9,7 @@ import type { DiagnosticRevealTarget } from "../types/diagnostics";
  */
 export function registerWebview(context: vscode.ExtensionContext) {
     extension.webview = new LiquidJavaWebviewProvider(context.extensionUri);
+    let pendingDiagnosticReveal: DiagnosticRevealTarget | undefined;
 
     // webview provider
     context.subscriptions.push(
@@ -17,8 +18,15 @@ export function registerWebview(context: vscode.ExtensionContext) {
     // show view command
     context.subscriptions.push(
         vscode.commands.registerCommand("liquidjava.showView", async (diagnostic?: DiagnosticRevealTarget) => {
+            const isVisible = extension.webview?.isVisible();
             await vscode.commands.executeCommand("liquidJavaView.focus");
-            if (diagnostic) extension.webview?.sendMessage({ type: "revealDiagnostic", diagnostic });
+            if (!diagnostic) return; 
+            
+            if (isVisible) {
+                extension.webview?.sendMessage({ type: "revealDiagnostic", diagnostic });
+            } else {
+                pendingDiagnosticReveal = diagnostic;
+            }
         })
     );
     // listen for messages from the webview
@@ -30,6 +38,10 @@ export function registerWebview(context: vscode.ExtensionContext) {
                 if (extension.context) extension.webview?.sendMessage({ type: "context", context: extension.context , errorAtCursor: extension.errorAtCursor });
                 if (extension.stateMachine) extension.webview?.sendMessage({ type: "fsm", sm: extension.stateMachine });
                 if (extension.status) extension.webview?.sendMessage({ type: "status", status: extension.status });
+                if (pendingDiagnosticReveal) {
+                    extension.webview?.sendMessage({ type: "revealDiagnostic", diagnostic: pendingDiagnosticReveal });
+                    pendingDiagnosticReveal = undefined;
+                }
             }
         })
     );

--- a/client/src/webview/styles.ts
+++ b/client/src/webview/styles.ts
@@ -361,23 +361,32 @@ export function getStyles(): string {
             text-align: right;
         }
         .vc-chain {
-            display: flex;
-            flex-direction: column;
-            gap: 0.25rem;
+            display: table;
+            width: 100%;
+            border-spacing: 0 0.25rem;
             min-width: 0;
         }
         .vc-line {
-            display: flex;
-            align-items: flex-start;
-            gap: 0.5rem;
+            display: table-row;
+        }
+        .vc-binder-cell,
+        .vc-predicate-cell {
+            display: table-cell;
             min-width: 0;
             padding: 0.0625rem 0.25rem;
-            border-radius: 3px;
-        }
-        .vc-line-content {
-            flex: 0 1 auto;
-            min-width: 0;
             overflow-wrap: anywhere;
+            vertical-align: top;
+        }
+        .vc-binder-cell {
+            min-height: 1.2em;
+            padding-right: 0.75rem;
+            color: var(--vscode-descriptionForeground);
+            white-space: nowrap;
+            width: 1%;
+        }
+        .vc-predicate-cell {
+            color: var(--vscode-editor-foreground);
+            width: 99%;
         }
         .vc-node {
             display: inline;

--- a/client/src/webview/styles.ts
+++ b/client/src/webview/styles.ts
@@ -362,7 +362,7 @@ export function getStyles(): string {
         }
         .vc-chain {
             display: grid;
-            grid-template-columns: max-content minmax(0, 1fr);
+            grid-template-columns: fit-content(40%) minmax(0, 1fr);
             row-gap: 0.25rem;
             width: 100%;
             min-width: 0;
@@ -388,7 +388,7 @@ export function getStyles(): string {
             min-height: 1.2em;
             padding-right: 0.75rem;
             color: var(--vscode-descriptionForeground);
-            white-space: nowrap;
+            white-space: normal;
         }
         .vc-predicate-cell {
             color: var(--vscode-editor-foreground);

--- a/client/src/webview/styles.ts
+++ b/client/src/webview/styles.ts
@@ -361,9 +361,10 @@ export function getStyles(): string {
             text-align: right;
         }
         .vc-chain {
-            display: table;
+            display: grid;
+            grid-template-columns: max-content minmax(0, 1fr);
+            row-gap: 0.25rem;
             width: 100%;
-            border-spacing: 0 0.25rem;
             min-width: 0;
         }
         .counterexample-container .vc-chain {
@@ -375,26 +376,25 @@ export function getStyles(): string {
             overflow-wrap: anywhere;
         }
         .vc-line {
-            display: table-row;
+            display: contents;
         }
         .vc-binder-cell,
         .vc-predicate-cell {
-            display: table-cell;
             min-width: 0;
             padding: 0.0625rem 0.25rem;
             overflow-wrap: anywhere;
-            vertical-align: top;
         }
         .vc-binder-cell {
             min-height: 1.2em;
             padding-right: 0.75rem;
             color: var(--vscode-descriptionForeground);
             white-space: nowrap;
-            width: 1%;
         }
         .vc-predicate-cell {
             color: var(--vscode-editor-foreground);
-            width: 99%;
+        }
+        .vc-predicate-cell:only-child {
+            grid-column: 1 / -1;
         }
         .vc-node {
             display: inline;

--- a/client/src/webview/styles.ts
+++ b/client/src/webview/styles.ts
@@ -366,6 +366,14 @@ export function getStyles(): string {
             border-spacing: 0 0.25rem;
             min-width: 0;
         }
+        .counterexample-container .vc-chain {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+        .counterexample-line {
+            overflow-wrap: anywhere;
+        }
         .vc-line {
             display: table-row;
         }

--- a/client/src/webview/styles.ts
+++ b/client/src/webview/styles.ts
@@ -161,7 +161,7 @@ export function getStyles(): string {
         }
         .diagnostic-item {
             background-color: var(--vscode-textCodeBlock-background);
-            padding: 0.5rem 5rem 0.5rem 1rem;
+            padding: 0.5rem 1rem;
             margin-bottom: 1rem;
             border-radius: 4px;
             position: relative;

--- a/client/src/webview/views/diagnostics/counterexample.ts
+++ b/client/src/webview/views/diagnostics/counterexample.ts
@@ -1,5 +1,4 @@
 import { renderHighlightedInlineExpression } from "../../highlighting";
-import { renderVCLine } from "./vc-changes";
 
 function getCounterexampleLines(counterexample: string): string[] {
     return counterexample
@@ -15,7 +14,11 @@ export function renderCounterexample(counterexample: string): string {
     return /*html*/`
         <div class="container vc-container counterexample-container">
             <div class="vc-chain">
-                ${lines.map(line => renderVCLine(renderHighlightedInlineExpression(line))).join("")}
+                ${lines.map(line => /*html*/`
+                    <div class="counterexample-line">
+                        <span class="vc-node">${renderHighlightedInlineExpression(line)}</span>
+                    </div>
+                `).join("")}
             </div>
         </div>
     `;

--- a/client/src/webview/views/diagnostics/counterexample.ts
+++ b/client/src/webview/views/diagnostics/counterexample.ts
@@ -1,0 +1,22 @@
+import { renderHighlightedInlineExpression } from "../../highlighting";
+import { renderVCLine } from "./vc-changes";
+
+function getCounterexampleLines(counterexample: string): string[] {
+    return counterexample
+        .split("&&")
+        .map(assignment => assignment.trim())
+        .filter(Boolean);
+}
+
+export function renderCounterexample(counterexample: string): string {
+    const lines = getCounterexampleLines(counterexample);
+    if (lines.length === 0) return "";
+
+    return /*html*/`
+        <div class="container vc-container counterexample-container">
+            <div class="vc-chain">
+                ${lines.map(line => renderVCLine(renderHighlightedInlineExpression(line))).join("")}
+            </div>
+        </div>
+    `;
+}

--- a/client/src/webview/views/diagnostics/errors.ts
+++ b/client/src/webview/views/diagnostics/errors.ts
@@ -1,4 +1,5 @@
 import { renderDiagnosticDataAttributes, renderExpressionSection, renderDiagnosticHeader, renderCustomSection, renderLocation, renderDiagnosticContextButton } from "../sections";
+import { renderCounterexample } from "./counterexample";
 import { renderVCImplication } from "./vc-implications";
 import type {
     ArgumentMismatchError,
@@ -36,7 +37,7 @@ const errorContentRenderers: ErrorRendererMap = {
     'refinement-error': (e: RefinementError) => /*html*/ `
         ${renderExpressionSection('Expected', e.expected)}
         ${renderCustomSection('Found', renderVCImplication(e, e.found))}
-        ${e.counterexample ? renderExpressionSection('Counterexample', e.counterexample) : ''}
+        ${e.counterexample ? renderCustomSection('Counterexample', renderCounterexample(e.counterexample)) : ''}
     `,
     'state-refinement-error': (e: StateRefinementError) => /*html*/ `
         ${renderExpressionSection('Expected', e.expected)}

--- a/client/src/webview/views/diagnostics/vc-changes.ts
+++ b/client/src/webview/views/diagnostics/vc-changes.ts
@@ -36,11 +36,9 @@ function getImplicationLines(node: VCImplication): string[] {
 
 function renderVCLine(line: string, className = "", predicateContent?: string): string {
     const { binder, type, predicate } = parseImplicationLine(line);
-    const title = binder && type ? ` title="${escapeHtml(`${binder.slice(1)}: ${type}`)}"` : "";
-
     return /*html*/`
         <div class="vc-line ${className}">
-            <div class="vc-binder-cell"${title}><span class="vc-node vc-binder">${escapeHtml(binder)}</span></div>
+            <div class="vc-binder-cell"><span class="vc-node vc-binder" title="${type}">${escapeHtml(binder)}</span></div>
             <div class="vc-predicate-cell"><span class="vc-node">${predicateContent ?? renderHighlightedInlineExpression(predicate)}</span></div>
         </div>
     `;

--- a/client/src/webview/views/diagnostics/vc-changes.ts
+++ b/client/src/webview/views/diagnostics/vc-changes.ts
@@ -38,7 +38,7 @@ export function renderVCLine(line: string, className = "", predicateContent?: st
     const { binder, type, predicate } = parseImplicationLine(line);
     return /*html*/`
         <div class="vc-line ${className}">
-            <div class="vc-binder-cell"><span class="vc-node vc-binder" title="${type}">${escapeHtml(binder)}</span></div>
+            ${binder ? /*html*/`<div class="vc-binder-cell"><span class="vc-node vc-binder" title="${type}">${escapeHtml(binder)}</span></div>` : ""}
             <div class="vc-predicate-cell"><span class="vc-node">${predicateContent ?? renderHighlightedInlineExpression(predicate)}</span></div>
         </div>
     `;

--- a/client/src/webview/views/diagnostics/vc-changes.ts
+++ b/client/src/webview/views/diagnostics/vc-changes.ts
@@ -1,5 +1,6 @@
 import type { VCImplication } from "../../../types/vc-implications";
 import { renderHighlightedInlineExpression } from "../../highlighting";
+import { escapeHtml } from "../../utils";
 
 type ChangeKind = "unchanged" | "removed" | "added";
 type DiffOperation<T> = { kind: ChangeKind; value: T };
@@ -7,23 +8,40 @@ type DiffOperation<T> = { kind: ChangeKind; value: T };
 const MIN_LINE_SIMILARITY = 0.3;
 const TOKEN_PATTERN = /\s+|-->|&&|\|\||==|!=|<=|>=|[a-zA-Z_#][a-zA-Z0-9_#⁰¹²³⁴⁵⁶⁷⁸⁹]*|\d+(?:\.\d+)?|[^\s]/gu;
 const WHITESPACE_PATTERN = /^\s+$/u;
+const VC_LINE_SEPARATOR = "\t";
+
+function hasBinder(node: VCImplication): boolean {
+    return typeof node.name === "string" && node.name.length > 0;
+}
+
+function formatImplicationLine(node: VCImplication): string {
+    const binder = hasBinder(node) ? `∀${node.name}` : "";
+    const type = typeof node.type === "string" ? node.type : "";
+    return [binder, type, node.predicate].join(VC_LINE_SEPARATOR);
+}
+
+function parseImplicationLine(line: string): { binder: string; type: string; predicate: string } {
+    const [binder = "", type = "", predicate = ""] = line.split(VC_LINE_SEPARATOR);
+    return { binder, type, predicate };
+}
 
 function getImplicationLines(node: VCImplication): string[] {
     const lines: string[] = [];
     for (let current: VCImplication | null = node; current; current = current.next) {
-        if (
-            current.next
-            && (current.name === null || current.type === null || current.predicate === "true")
-        ) continue;
-        lines.push(current.predicate);
+        if (current.next && !hasBinder(current)) continue;
+        lines.push(formatImplicationLine(current));
     }
     return lines;
 }
 
-function renderVCLine(content: string, className = ""): string {
+function renderVCLine(line: string, className = "", predicateContent?: string): string {
+    const { binder, type, predicate } = parseImplicationLine(line);
+    const title = binder && type ? ` title="${escapeHtml(`${binder.slice(1)}: ${type}`)}"` : "";
+
     return /*html*/`
         <div class="vc-line ${className}">
-            <div class="vc-line-content"><span class="vc-node">${content}</span></div>
+            <div class="vc-binder-cell"${title}><span class="vc-node vc-binder">${escapeHtml(binder)}</span></div>
+            <div class="vc-predicate-cell"><span class="vc-node">${predicateContent ?? renderHighlightedInlineExpression(predicate)}</span></div>
         </div>
     `;
 }
@@ -158,16 +176,19 @@ function renderChangedDestinationLines(removed: string[], added: string[]): stri
     return alignChangedLines(removed, added)
         .map(([before, after]) => {
             if (after === undefined) return "";
-            if (before === undefined) return renderVCLine(renderChangedFragment(after));
-            const change = renderDestinationTokenDiff(before, after);
-            return renderVCLine(change.content, change.hasAddedContent ? "" : "vc-change-line");
+            if (before === undefined) return renderVCLine(after, "vc-change-line");
+            const change = renderDestinationTokenDiff(
+                parseImplicationLine(before).predicate,
+                parseImplicationLine(after).predicate,
+            );
+            return renderVCLine(after, change.hasAddedContent ? "" : "vc-change-line", change.content);
         })
         .join("");
 }
 
 export function renderImplication(node: VCImplication): string {
     return getImplicationLines(node)
-        .map(predicate => renderVCLine(renderHighlightedInlineExpression(predicate)))
+        .map(line => renderVCLine(line))
         .join("");
 }
 
@@ -185,7 +206,7 @@ export function renderImplicationChange(before: VCImplication, after: VCImplicat
     for (const operation of operations) {
         if (operation.kind === "unchanged") {
             flushChanges();
-            html += renderVCLine(renderHighlightedInlineExpression(operation.value));
+            html += renderVCLine(operation.value);
             continue;
         }
         changed[operation.kind].push(operation.value);

--- a/client/src/webview/views/diagnostics/vc-changes.ts
+++ b/client/src/webview/views/diagnostics/vc-changes.ts
@@ -34,7 +34,7 @@ function getImplicationLines(node: VCImplication): string[] {
     return lines;
 }
 
-function renderVCLine(line: string, className = "", predicateContent?: string): string {
+export function renderVCLine(line: string, className = "", predicateContent?: string): string {
     const { binder, type, predicate } = parseImplicationLine(line);
     return /*html*/`
         <div class="vc-line ${className}">

--- a/client/src/webview/views/diagnostics/vc-implications.ts
+++ b/client/src/webview/views/diagnostics/vc-implications.ts
@@ -22,7 +22,7 @@ function renderStepHeader(
 ): string {
     const currStep = stepCount - index;
     const simplification = current.simplification?.trim();
-    const label = escapeHtml(simplification || "Original");
+    const label = escapeHtml(index === 0 ? "Simplified" : simplification || "Original");
 
     return /*html*/`
         <div class="vc-step-header">


### PR DESCRIPTION
This PR makes some improvements to the UI of diagnostics in the webview:
1. VCs are now displayed in a table layout that include both their binders and predicates
2. The binder type is hidden but shown when hovering the binder
3. Each counterexample assignment is displayed in a single line instead of joined with "&&"
4. The last simplification steps displays "Simplified" instead of the name of the simplification pass
5. The diagnostic reveal works even if the webview is closed

<img width="588" height="556" alt="image" src="https://github.com/user-attachments/assets/a61708ce-e7ca-4214-979e-6c3b500f33e2" />


